### PR TITLE
Release canvas on CanvasSurface#destroy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
 
+## 0.10.15
+* `CanvasSurface#destroy()` で `canvas` を解放するように (iOSメモリ対策)
+
 ## 0.10.14
 * 初期リリース

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/canvas/CanvasSurface.ts
+++ b/src/canvas/CanvasSurface.ts
@@ -16,6 +16,14 @@ export class CanvasSurface extends g.Surface {
 		this._renderer = undefined;
 	}
 
+	destroy(): void {
+		this.canvas.width = 1;
+		this.canvas.height = 1;
+		this.canvas = null;
+		this._renderer = null;
+		super.destroy();
+	}
+
 	renderer(): g.Renderer {
 		if (!this._renderer) {
 			this._renderer = new Context2DRenderer(this, this._context);


### PR DESCRIPTION
`CanvasSurface#destroy()` で `this.canvas` を解放するようにします。この対応は master ブランチには既に含まれています。master 取り込み済みのためセルフマージします。
