### PR TITLE
Add "anonymous" to image element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.7
+* HTMLImageAsset#_load 時に img タグに対して `crossOrigin = "anonymous"` を付加するように
+
 ## 1.5.6
 * WebAudioPlayer#stop, HTMLAudioPlayer#stop で currentAudio が存在しない場合でも g.AudioPlayer#stop を呼び出すように修正
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/asset/HTMLImageAsset.ts
+++ b/src/asset/HTMLImageAsset.ts
@@ -42,6 +42,7 @@ export class HTMLImageAsset extends g.ImageAsset {
 			this.data = image;
 			loader._onAssetLoad(this);
 		};
+		image.crossOrigin = "anonymous";
 		image.src = this.path;
 	}
 


### PR DESCRIPTION
## このPullRequestが解決する内容
プライマリキャンバスの再利用を有効にするため `ImageElement#crossOrigin` を `"anonymous"` に設定します。
https://developer.mozilla.org/ja/docs/Web/HTML/Element/img#Attributes