### PR TITLE
Remove "anonymous" when protocol is "files:" from HTMLImageAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.8
+* window.location.protocol が `http:`, `https:` 以外の場合はHTMLImageAsset#_load 時に img タグに対して `crossOrigin = "anonymous"` を付加しないように
+
 ## 1.5.7
 * HTMLImageAsset#_load 時に img タグに対して `crossOrigin = "anonymous"` を付加するように
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/asset/HTMLImageAsset.ts
+++ b/src/asset/HTMLImageAsset.ts
@@ -42,7 +42,9 @@ export class HTMLImageAsset extends g.ImageAsset {
 			this.data = image;
 			loader._onAssetLoad(this);
 		};
-		image.crossOrigin = "anonymous";
+		if (window.location.protocol === "http:" || window.location.protocol === "https:") {
+			image.crossOrigin = "anonymous";
+		}
 		image.src = this.path;
 	}
 


### PR DESCRIPTION
## このPullRequestが解決する内容
#3 にて追加した `ImageElement#crossOrigin` が akashic-cli-export-html で出力した html ファイルにて cross origin policy に引っかかっていたため、これを protocol が `http:` または `https:` 以外のときには付加しないように修正します。