### PR TITLE
fix HTMLAudioPlayer.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.10.16
+* `HTMLAudioPlayer#play()` 実行時にエラーが表示されていたので修正
+  * 上記エラーは表示されるだけで動作には影響がなかった
+
 ## 0.10.15
 * `CanvasSurface#destroy()` で `canvas` を解放するように (iOSメモリ対策)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
+++ b/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
@@ -33,7 +33,6 @@ export class HTMLAudioPlayer extends g.AudioPlayer implements AudioPlayer { priv
 			autoPlayHelper.setupChromeMEIWorkaround(audio);
 			audio.volume = this._calculateVolume();
 			audio.play().catch((err) => { /* user interactの前にplay()を呼ぶとエラーになる。これはHTMLAudioAutoplayHelperで吸収する */});
-			audio.play();
 			audio.loop = asset.loop;
 			audio.addEventListener("ended", this._endedEventHandler, false);
 			audio.addEventListener("play", this._onPlayEventHandler, false);


### PR DESCRIPTION
### 概要
* `audio.play()`が二重に呼ばれていたため、html-exportされたゲーム実行時に`Uncaught (in promise) DOMException`というエラーが出ていた

### やったこと
* catchを行っていない方の`audio.play()`を削除した