### PR TITLE
make v1.5.9: revert crossorigin attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # CHANGELOG
 
+## 1.5.9
+* `crossOrigin` 属性の追加を revert
+
 ## 1.5.8
-* window.location.protocol が `http:`, `https:` 以外の場合はHTMLImageAsset#_load 時に img タグに対して `crossOrigin = "anonymous"` を付加しないように
+* window.location.protocol が `http:`, `https:` 以外の場合はHTMLImageAsset#\_load 時に img タグに対して `crossOrigin = "anonymous"` を付加しないように
 
 ## 1.5.7
-* HTMLImageAsset#_load 時に img タグに対して `crossOrigin = "anonymous"` を付加するように
+* HTMLImageAsset#\_load 時に img タグに対して `crossOrigin = "anonymous"` を付加するように
 
 ## 1.5.6
 * WebAudioPlayer#stop, HTMLAudioPlayer#stop で currentAudio が存在しない場合でも g.AudioPlayer#stop を呼び出すように修正

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/asset/HTMLImageAsset.ts
+++ b/src/asset/HTMLImageAsset.ts
@@ -42,9 +42,6 @@ export class HTMLImageAsset extends g.ImageAsset {
 			this.data = image;
 			loader._onAssetLoad(this);
 		};
-		if (window.location.protocol === "http:" || window.location.protocol === "https:") {
-			image.crossOrigin = "anonymous";
-		}
 		image.src = this.path;
 	}
 


### PR DESCRIPTION
やってみて色々問題の発覚した `crossorigin` 属性を削除します。
変更点自明のためセルフマージします。
