### PR TITLE
Add "anonymous" to image element when untainted flag is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.11
+* ImageAsset#hint に `untainted: true` が与えられたときに img タグに対して `crossOrigin = "anonymous"` を付加するように
+
 ## 1.5.10
 * ゲーム開始前にタッチイベントが発生した場合、エラーになるケースを修正
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "uglify-js": "~3.3.9"
   },
   "dependencies": {
-    "@akashic/akashic-engine": "~2.4.2"
+    "@akashic/akashic-engine": "~2.4.14"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"

--- a/src/asset/HTMLImageAsset.ts
+++ b/src/asset/HTMLImageAsset.ts
@@ -35,6 +35,10 @@ export class HTMLImageAsset extends g.ImageAsset {
 
 	_load(loader: g.AssetLoadHandler): void {
 		var image = new Image();
+
+		if (this.hint && this.hint.untainted) {
+			image.crossOrigin = "anonymous";
+		}
 		image.onerror = () => {
 			loader._onAssetError(this, g.ExceptionFactory.createAssetLoadError("HTMLImageAsset unknown loading error"));
 		};


### PR DESCRIPTION
## このPullRequestが解決する内容
`ImageAsset#hint#untainted` が true の場合、 `ImageElement#crossOrigin` に `"anonymous"` が付加されるように修正します。
#3 の本対応になります。