### PR TITLE
Fix error for last line comments in script assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.12
+* ScriptAsset の最終行が1行コメントの場合にエラーになる問題を修正
+
 ## 1.5.11
 * ImageAsset#hint に `untainted: true` が与えられたときに img タグに対して `crossOrigin = "anonymous"` を付加するように
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/asset/XHRScriptAsset.ts
+++ b/src/asset/XHRScriptAsset.ts
@@ -3,7 +3,7 @@ import { XHRLoader } from "../utils/XHRLoader";
 
 export class XHRScriptAsset extends g.ScriptAsset {
 	static PRE_SCRIPT: string = "(function(exports, require, module, __filename, __dirname) {";
-	static POST_SCRIPT: string = "})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);";
+	static POST_SCRIPT: string = "\n})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);";
 
 	constructor(id: string, path: string) {
 		super(id, path);


### PR DESCRIPTION
掲題どおり。スクリプトアセットの最終行が `//` コメントだと、スクリプトの前後につけている snippet の後半が巻き込まれてコメントアウトされてしまい、パースエラーが起きていました。

特に sourceMappingURL のコメントが末尾にある場合に直撃します。よく今まで問題になっていなかったという感じですが、 sandbox だと例外的に回避できる上、 akashic export で bundle してしまえば生じないので実運用上の発覚が遅れたようです。

修正自明のためセルフマージします。
