### PR TITLE
Share the AudioContext instance to avoid allocation faillure on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.13
+* Edge/Safari でゲームが実行できないことがある (new AudioContext() が null を返すことがある) 問題を修正
+
 ## 1.5.12
 * ScriptAsset の最終行が1行コメントの場合にエラーになる問題を修正
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",


### PR DESCRIPTION
pdi-browser が複数回ロードされていくと、 AudioContext のインスタンスが増加し、 Safari や Edge でエラーになる問題を修正します。具体的には、グローバル変数を作ってしまい、そこでインスタンスを共有します。

akashic-sandbox に組み込み、音声を鳴らすゲームが問題なく動作することを確認しています。
