### PR TITLE
コンテンツ破棄時に画像・音声を握り潰すための対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased Changes
+* surfaceの削除と音量ミュートを実行する `Platform#destroy()` を追加
+
 ## 1.5.13
 * Edge/Safari でゲームが実行できないことがある (new AudioContext() が null を返すことがある) 問題を修正
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased Changes
+## 1.5.14
 * surfaceの削除と音量ミュートを実行する `Platform#destroy()` を追加
 
 ## 1.5.13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",
@@ -40,7 +40,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "@akashic/akashic-pdi": "file:../akashic-pdi/akashic-akashic-pdi-2.4.1.tgz",
+    "@akashic/akashic-pdi": "~2.4.2",
     "@akashic/amflow": "~0.2.1",
     "@akashic/playlog": "~1.3.0",
     "@types/node": "~9.4.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "@akashic/akashic-pdi": "~2.4.0",
+    "@akashic/akashic-pdi": "file:../akashic-pdi/akashic-akashic-pdi-2.4.1.tgz",
     "@akashic/amflow": "~0.2.1",
     "@akashic/playlog": "~1.3.0",
     "@types/node": "~9.4.2",

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -179,4 +179,9 @@ export class Platform implements pdi.Platform {
 		if (this._audioManager)
 			return this._audioManager.getMasterVolume();
 	}
+
+	destroy(): void {
+		this.setRendererRequirement(undefined);
+		this.setMasterVolume(0);
+	}
 }


### PR DESCRIPTION
### 概要
* コンテンツ破棄時に画像・音声を握り潰すための処理を`Platform#destroy()`に実装しました。

### やったこと
* `Platform#destroy()`で以下の処理を行うようにしました。
  * surfaceの破棄
  * 音量をミュートにする

### マージ前に必ずやること
* https://github.com/akashic-games/akashic-pdi/pull/1 がマージ且つpublishされた後に、package.jsonで最新バージョンの`@akashic/akashic-pdi`を指定