### PR TITLE
コンテンツ破棄時に画像・音声を握り潰すための対応(v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased Changes
+* surfaceの削除と音量ミュートを実行する `Platform#destroy()` を追加
+
 ## 0.10.18
 * ScriptAsset の最終行が1行コメントの場合にエラーになる問題を修正
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased Changes
+## 0.10.19
 * surfaceの削除と音量ミュートを実行する `Platform#destroy()` を追加
 
 ## 0.10.18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/index.d.ts",
@@ -33,7 +33,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "@akashic/akashic-pdi": "file:../akashic-pdi/akashic-akashic-pdi-1.10.2.tgz",
+    "@akashic/akashic-pdi": "~1.10.3",
     "@akashic/amflow": "~0.2.1",
     "@akashic/playlog": "~1.3.0",
     "@types/node": "~9.4.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "@akashic/akashic-pdi": "~1.10.0",
+    "@akashic/akashic-pdi": "file:../akashic-pdi/akashic-akashic-pdi-1.10.2.tgz",
     "@akashic/amflow": "~0.2.1",
     "@akashic/playlog": "~1.3.0",
     "@types/node": "~9.4.2",

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -179,4 +179,9 @@ export class Platform implements pdi.Platform {
 		if (this._audioManager)
 			return this._audioManager.getMasterVolume();
 	}
+
+	destroy(): void {
+		this.setRendererRequirement(undefined);
+		this.setMasterVolume(0);
+	}
 }


### PR DESCRIPTION
### 概要
* コンテンツ破棄時に画像・音声を握り潰すための処理を`Platform#destroy()`に実装しました。

### やったこと
* `Platform#destroy()`で以下の処理を行うようにしました。
  * surfaceの破棄
  * 音量をミュートにする

### マージ前に必ずやること
* https://github.com/akashic-games/akashic-pdi/pull/2 がマージ且つpublishされた後に、package.jsonで1系最新バージョンの`@akashic/akashic-pdi`を指定