### PR TITLE
Add ProxyAudioPlugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,9 @@ import { WebAudioPlugin } from "./plugin/WebAudioPlugin/WebAudioPlugin";
 export { HTMLAudioPlugin };
 export { WebAudioPlugin };
 
+// TODO 削除。誰も使っていない
 import { PostMessageAudioPlugin } from "./plugin/PostMessageAudioPlugin/PostMessageAudioPlugin";
 export { PostMessageAudioPlugin };
+
+import { ProxyAudioPlugin } from "./plugin/ProxyAudioPlugin/ProxyAudioPlugin";
+export { ProxyAudioPlugin };

--- a/src/plugin/AudioPluginManager.ts
+++ b/src/plugin/AudioPluginManager.ts
@@ -3,7 +3,6 @@ import { AudioPlugin } from "./AudioPlugin";
 import { AudioPluginStatic } from "./AudioPluginStatic";
 /*
  Audioプラグインを登録し、現在登録しているプラグインを管理するクラス
- 仕様は docs/audio-plugin.md を参照
 
  TODO: 各Gameインスタンスが一つのAudioプラグインしか持たないので、
  PluginManagerが状態をもたずにGame自体にpluginを登録する方式もあり
@@ -12,37 +11,28 @@ export class AudioPluginManager {
 	private _activePlugin: AudioPlugin;
 
 	constructor() {
-		this._activePlugin = undefined;
+		this._activePlugin = null;
 	}
 
 	getActivePlugin(): AudioPlugin {
-		if (this._activePlugin === undefined) {
-			return null;
-		}
 		return this._activePlugin;
 	}
 
 	// Audioプラグインに登録を行い、どれか一つでも成功ならtrue、それ以外はfalseを返す
-	tryInstallPlugin(plugins: AudioPluginStatic[]): boolean {
-		var PluginConstructor = this.findFirstAvailablePlugin(plugins);
-		if (PluginConstructor) {
-			this._activePlugin = new PluginConstructor();
-			return true;
-		}
-		// Step 3
-		return false;
-	}
-
-
-	findFirstAvailablePlugin(plugins: AudioPluginStatic[]): AudioPluginStatic {
+	tryInstallPlugin(plugins: (AudioPluginStatic | AudioPlugin)[]): boolean {
 		for (var i = 0, len = plugins.length; i < len; i++) {
-			// Step 1
-			var plugin = plugins[i];
-			// Step 2
-			if (plugin.isSupported()) {
-				return plugin;
+			var p = plugins[i];
+			if ((p as any).isSupported) {
+				const PluginConstructor = (p as AudioPluginStatic);
+				if (PluginConstructor.isSupported()) {
+					this._activePlugin = new PluginConstructor();
+					return true;
+				}
+			} else {
+				this._activePlugin = p as AudioPlugin;
+				return true;
 			}
 		}
+		return false;
 	}
 }
-

--- a/src/plugin/ProxyAudioPlugin/ProxyAudioAsset.ts
+++ b/src/plugin/ProxyAudioPlugin/ProxyAudioAsset.ts
@@ -1,0 +1,39 @@
+import * as g from "@akashic/akashic-engine";
+import { ProxyAudioHandlerSet } from "./ProxyAudioHandlerSet";
+
+export class ProxyAudioAsset extends g.AudioAsset {
+	private _handlerSet: ProxyAudioHandlerSet;
+
+	constructor(
+		handlerSet: ProxyAudioHandlerSet, id: string, assetPath: string,
+		duration: number, system: g.AudioSystem, loop: boolean, hint: g.AudioAssetHint
+	) {
+		super(id, assetPath, duration, system, loop, hint);
+		this._handlerSet = handlerSet;
+	}
+
+	destroy(): void {
+		this._handlerSet.unloadAudioAsset(this.id);
+		super.destroy();
+	}
+
+	_load(loader: g.AssetLoadHandler): void {
+		this._handlerSet.loadAudioAsset({
+			id: this.id,
+			assetPath: this.path,
+			duration: this.duration,
+			loop: this.loop,
+			hint: this.hint
+		}, (err?: any) => {
+			if (err) {
+				loader._onAssetError(this, g.ExceptionFactory.createAssetLoadError(err));
+			} else {
+				loader._onAssetLoad(this);
+			}
+		});
+	}
+
+	_assetPathFilter(path: string): string {
+		return path;
+	}
+}

--- a/src/plugin/ProxyAudioPlugin/ProxyAudioHandlerSet.ts
+++ b/src/plugin/ProxyAudioPlugin/ProxyAudioHandlerSet.ts
@@ -1,0 +1,22 @@
+export interface AudioAssetHintParameterObject {
+	streaming?: boolean;
+}
+
+export interface LoadAudioAssetParameterObject {
+	id: string;
+	assetPath: string;
+	duration: number;
+	loop: boolean;
+	hint: AudioAssetHintParameterObject;
+}
+
+export interface ProxyAudioHandlerSet {
+	loadAudioAsset: (parameters: LoadAudioAssetParameterObject, handler: (err?: any) => void) => void;
+	unloadAudioAsset: (assetId: string) => void;
+	createAudioPlayer: (assetId: string) => string;
+	destroyAudioPlayer: (audioAssetId: string) => void;
+	playAudioPlayer: (audioPlayerId: string) => void;
+	stopAudioPlayer: (audioPlayerId: string) => void;
+	changeAudioVolume: (audioPlayerId: string, volume: number) => void;
+	changeAudioPlaybackRate: (audioPlayerId: string, rate: number) => void;
+}

--- a/src/plugin/ProxyAudioPlugin/ProxyAudioHandlerSet.ts
+++ b/src/plugin/ProxyAudioPlugin/ProxyAudioHandlerSet.ts
@@ -14,7 +14,7 @@ export interface ProxyAudioHandlerSet {
 	loadAudioAsset: (parameters: LoadAudioAssetParameterObject, handler: (err?: any) => void) => void;
 	unloadAudioAsset: (assetId: string) => void;
 	createAudioPlayer: (assetId: string) => string;
-	destroyAudioPlayer: (audioAssetId: string) => void;
+	destroyAudioPlayer: (audioPlayerId: string) => void;
 	playAudioPlayer: (audioPlayerId: string) => void;
 	stopAudioPlayer: (audioPlayerId: string) => void;
 	changeAudioVolume: (audioPlayerId: string, volume: number) => void;

--- a/src/plugin/ProxyAudioPlugin/ProxyAudioPlayer.ts
+++ b/src/plugin/ProxyAudioPlugin/ProxyAudioPlayer.ts
@@ -1,0 +1,78 @@
+import * as g from "@akashic/akashic-engine";
+import { AudioManager } from "../../AudioManager";
+import { AudioPlayer } from "../AudioPlayer";
+import { ProxyAudioAsset } from "./ProxyAudioAsset";
+import { ProxyAudioHandlerSet } from "./ProxyAudioHandlerSet";
+
+export class ProxyAudioPlayer extends g.AudioPlayer implements AudioPlayer {
+	private _audioPlayerId: string | null;
+	private _handlerSet: ProxyAudioHandlerSet;
+	private _manager: AudioManager;
+	private _durationWaitTimer: any;
+	private _handleDurationPassed_bound: () => void;
+
+	constructor(handlerSet: ProxyAudioHandlerSet, system: g.AudioSystem, manager: AudioManager) {
+		super(system);
+		this._audioPlayerId = null;
+		this._handlerSet = handlerSet;
+		this._manager = manager;
+		this._durationWaitTimer = null;
+		this._handleDurationPassed_bound = () => this._handleDurationPassed();
+	}
+
+	changeVolume(volume: number): void {
+		super.changeVolume(volume);
+		this._notifyVolumeToHandler();
+	}
+
+	_changeMuted(muted: boolean): void {
+		super._changeMuted(muted);
+		this._notifyVolumeToHandler();
+	}
+
+	play(asset: ProxyAudioAsset): void {
+		if (this._audioPlayerId != null) {
+			this.stop();
+		}
+		this._audioPlayerId = this._handlerSet.createAudioPlayer(asset.id);
+		this._handlerSet.changeAudioVolume(this._audioPlayerId, this._calculateVolume());
+		this._handlerSet.playAudioPlayer(this._audioPlayerId);
+		this._durationWaitTimer = setTimeout(this._handleDurationPassed_bound, asset.duration);
+		super.play(asset);
+	}
+
+	stop(): void {
+		if (this._audioPlayerId != null) {
+			this._clearEndedEventHandler();
+			this._handlerSet.stopAudioPlayer(this._audioPlayerId); // 不要？
+			this._handlerSet.destroyAudioPlayer(this._audioPlayerId);
+			this._audioPlayerId = null;
+		}
+		super.stop();
+	}
+
+	notifyMasterVolumeChanged(): void {
+		this._notifyVolumeToHandler();
+	}
+
+	private _handleDurationPassed(): void {
+		this.stop();
+	}
+
+	private _clearEndedEventHandler(): void {
+		if (this._durationWaitTimer != null) {
+			clearTimeout(this._durationWaitTimer);
+			this._durationWaitTimer = null;
+		}
+	}
+
+	private _notifyVolumeToHandler(): void {
+		if (this._audioPlayerId != null) {
+			this._handlerSet.changeAudioVolume(this._audioPlayerId, this._calculateVolume());
+		}
+	}
+
+	private _calculateVolume(): number {
+		return this._muted ? 0 : this.volume * this._system.volume * this._manager.getMasterVolume();
+	}
+}

--- a/src/plugin/ProxyAudioPlugin/ProxyAudioPlayer.ts
+++ b/src/plugin/ProxyAudioPlugin/ProxyAudioPlayer.ts
@@ -8,16 +8,12 @@ export class ProxyAudioPlayer extends g.AudioPlayer implements AudioPlayer {
 	private _audioPlayerId: string | null;
 	private _handlerSet: ProxyAudioHandlerSet;
 	private _manager: AudioManager;
-	private _durationWaitTimer: any;
-	private _handleDurationPassed_bound: () => void;
 
 	constructor(handlerSet: ProxyAudioHandlerSet, system: g.AudioSystem, manager: AudioManager) {
 		super(system);
 		this._audioPlayerId = null;
 		this._handlerSet = handlerSet;
 		this._manager = manager;
-		this._durationWaitTimer = null;
-		this._handleDurationPassed_bound = () => this._handleDurationPassed();
 	}
 
 	changeVolume(volume: number): void {
@@ -37,14 +33,12 @@ export class ProxyAudioPlayer extends g.AudioPlayer implements AudioPlayer {
 		this._audioPlayerId = this._handlerSet.createAudioPlayer(asset.id);
 		this._handlerSet.changeAudioVolume(this._audioPlayerId, this._calculateVolume());
 		this._handlerSet.playAudioPlayer(this._audioPlayerId);
-		this._durationWaitTimer = setTimeout(this._handleDurationPassed_bound, asset.duration);
 		super.play(asset);
 	}
 
 	stop(): void {
 		if (this._audioPlayerId != null) {
-			this._clearEndedEventHandler();
-			this._handlerSet.stopAudioPlayer(this._audioPlayerId); // 不要？
+			this._handlerSet.stopAudioPlayer(this._audioPlayerId);
 			this._handlerSet.destroyAudioPlayer(this._audioPlayerId);
 			this._audioPlayerId = null;
 		}
@@ -53,17 +47,6 @@ export class ProxyAudioPlayer extends g.AudioPlayer implements AudioPlayer {
 
 	notifyMasterVolumeChanged(): void {
 		this._notifyVolumeToHandler();
-	}
-
-	private _handleDurationPassed(): void {
-		this.stop();
-	}
-
-	private _clearEndedEventHandler(): void {
-		if (this._durationWaitTimer != null) {
-			clearTimeout(this._durationWaitTimer);
-			this._durationWaitTimer = null;
-		}
 	}
 
 	private _notifyVolumeToHandler(): void {

--- a/src/plugin/ProxyAudioPlugin/ProxyAudioPlugin.ts
+++ b/src/plugin/ProxyAudioPlugin/ProxyAudioPlugin.ts
@@ -1,0 +1,29 @@
+"use strict";
+import * as g from "@akashic/akashic-engine";
+import { AudioPlugin } from "../AudioPlugin";
+import { ProxyAudioHandlerSet } from "./ProxyAudioHandlerSet";
+import { ProxyAudioAsset } from "./ProxyAudioAsset";
+import { ProxyAudioPlayer } from "./ProxyAudioPlayer";
+import { AudioManager } from "../../AudioManager";
+
+export class ProxyAudioPlugin implements AudioPlugin {
+	supportedFormats: string[] = [];
+
+	static isSupported(): boolean {
+		return true;
+	}
+
+	private _handlerSet: ProxyAudioHandlerSet;
+
+	constructor(handlerSet: ProxyAudioHandlerSet) {
+		this._handlerSet = handlerSet;
+	}
+
+	createAsset(id: string, assetPath: string, duration: number, system: g.AudioSystem, loop: boolean, hint: g.AudioAssetHint): g.AudioAsset {
+		return new ProxyAudioAsset(this._handlerSet, id, assetPath, duration, system, loop, hint);
+	}
+
+	createPlayer(system: g.AudioSystem, manager: AudioManager): g.AudioPlayer {
+		return new ProxyAudioPlayer(this._handlerSet, system, manager);
+	}
+}

--- a/src/plugin/ProxyAudioPlugin/ProxyAudioPlugin.ts
+++ b/src/plugin/ProxyAudioPlugin/ProxyAudioPlugin.ts
@@ -7,12 +7,11 @@ import { ProxyAudioPlayer } from "./ProxyAudioPlayer";
 import { AudioManager } from "../../AudioManager";
 
 export class ProxyAudioPlugin implements AudioPlugin {
-	supportedFormats: string[] = [];
-
 	static isSupported(): boolean {
 		return true;
 	}
 
+	supportedFormats: string[] = [];
 	private _handlerSet: ProxyAudioHandlerSet;
 
 	constructor(handlerSet: ProxyAudioHandlerSet) {


### PR DESCRIPTION
- 実際の音声再生処理をすべてコールバックに委ねる `AudioPlugin` 実装、 `ProxyAudioPlugin` を追加します。
- このクラスがコンストラクタ引数を取らざるを得ないことを鑑み、 `AudioPluginManager#tryInstallPlugins()` に、クラスでなく `AudioPlugin` 自体も渡せるようにします (この場合 new せずそのまま使う)。