### PR TITLE
バックサーフェスの描画時に context の状態が正常に初期化されていなかった件の修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.7.1
+* バックサーフェスの描画時に context の状態が正常に初期化されていなかった問題を修正
+
 ## 1.7.0
 * @akashic/akashic-engineのminor更新に伴うバージョンアップ
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/canvas/context2d/Context2DRenderer.ts
+++ b/src/canvas/context2d/Context2DRenderer.ts
@@ -17,10 +17,12 @@ export class Context2DRenderer extends g.Renderer {
 	begin(): void {
 		super.begin();
 		this.canvasRenderingContext2D.save();
+		this.context.save();
 	}
 
 	end(): void {
 		this.canvasRenderingContext2D.restore();
+		this.context.restore();
 		super.end();
 	}
 


### PR DESCRIPTION
## このPullRequestが解決する内容
`g.Renderer#begin()` , `g.Renderer#end()` の呼び出し時に `CanvasSurfaceContext#save()` , `CanvasSurfaceContext#restore()` を呼ぶようにします。
これにより、 `g.Pane` など内部で別の `CanvasSurfaceContext` を生成しているエンティティの描画時に、初期状態の `CanvasRenderingContext2D` が引き継がれてしまっていたバグを修正します。