### PR TITLE
MouseHandler が画面外で反応しない問題への対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unchanged releases
+* MouseHandler が画面外でキャンセルされてしまう問題を修正
+
 ## 1.8.0
 * @akashic/akashic-engineのminor更新に伴うバージョンアップ
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unchanged releases
+## 1.8.1
 * MouseHandler が画面外でキャンセルされてしまう問題を修正
 
 ## 1.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/handler/InputAbstractHandler.ts
+++ b/src/handler/InputAbstractHandler.ts
@@ -104,4 +104,14 @@ export class InputAbstractHandler {
 	getScale(): Scale {
 		return { x: this._xScale, y: this._yScale };
 	}
+
+	getOffsetPositionFromInputView(x: number, y: number): OffsetPosition {
+		// windowの左上を0,0とした時のinputViewのoffsetを取得する
+		var bounding = this.inputView.getBoundingClientRect();
+		var scale = this.getScale();
+		return {
+			offsetX: (x - Math.round(window.pageXOffset + bounding.left)) / scale.x,
+			offsetY: (y - Math.round(window.pageYOffset + bounding.top)) / scale.y
+		};
+	}
 }

--- a/src/handler/InputAbstractHandler.ts
+++ b/src/handler/InputAbstractHandler.ts
@@ -8,6 +8,11 @@ export interface Scale {
 	y: number;
 }
 
+export interface PagePosition {
+	pageX: number;
+	pageY: number;
+}
+
 /**
  * 入力ハンドラ。
  *
@@ -105,13 +110,13 @@ export class InputAbstractHandler {
 		return { x: this._xScale, y: this._yScale };
 	}
 
-	getOffsetPositionFromInputView(x: number, y: number): OffsetPosition {
+	getOffsetPositionFromInputView(position: PagePosition): OffsetPosition {
 		// windowの左上を0,0とした時のinputViewのoffsetを取得する
 		var bounding = this.inputView.getBoundingClientRect();
 		var scale = this.getScale();
 		return {
-			offsetX: (x - Math.round(window.pageXOffset + bounding.left)) / scale.x,
-			offsetY: (y - Math.round(window.pageYOffset + bounding.top)) / scale.y
+			offsetX: (position.pageX - Math.round(window.pageXOffset + bounding.left)) / scale.x,
+			offsetY: (position.pageY - Math.round(window.pageYOffset + bounding.top)) / scale.y
 		};
 	}
 }

--- a/src/handler/MouseHandler.ts
+++ b/src/handler/MouseHandler.ts
@@ -1,7 +1,6 @@
 import { InputAbstractHandler } from "./InputAbstractHandler";
 
 export class MouseHandler extends InputAbstractHandler {
-	private eventTarget: EventTarget;
 	private onMouseDown: (e: MouseEvent) => void;
 	private onMouseMove: (e: MouseEvent) => void;
 	private onMouseUp: (e: MouseEvent) => void;
@@ -11,8 +10,7 @@ export class MouseHandler extends InputAbstractHandler {
 		var identifier = 1;
 		this.onMouseDown = (e: MouseEvent) => {
 			if (e.button !== 0) return; // NOTE: 左クリック以外を受け付けない
-			this.eventTarget = e.target;
-			this.pointDown(identifier, e);
+			this.pointDown(identifier, this.getOffsetPositionFromInputView(e.pageX, e.pageY));
 			window.addEventListener("mousemove", this.onMouseMove, false);
 			window.addEventListener("mouseup", this.onMouseUp, false);
 			if (!this._disablePreventDefault) {
@@ -21,16 +19,14 @@ export class MouseHandler extends InputAbstractHandler {
 			}
 		};
 		this.onMouseMove = (e: MouseEvent) => {
-			if (e.target !== this.eventTarget) return; // 対象の要素が異なる場合、イベントを発火しない
-			this.pointMove(identifier, e);
+			this.pointMove(identifier, this.getOffsetPositionFromInputView(e.pageX, e.pageY));
 			if (!this._disablePreventDefault) {
 				e.stopPropagation();
 				e.preventDefault();
 			}
 		};
 		this.onMouseUp = (e: MouseEvent) => {
-			if (e.target !== this.eventTarget) return; // 対象の要素が異なる場合、イベントを発火しない
-			this.pointUp(identifier, e);
+			this.pointUp(identifier, this.getOffsetPositionFromInputView(e.pageX, e.pageY));
 			window.removeEventListener("mousemove", this.onMouseMove, false);
 			window.removeEventListener("mouseup", this.onMouseUp, false);
 			if (!this._disablePreventDefault) {

--- a/src/handler/MouseHandler.ts
+++ b/src/handler/MouseHandler.ts
@@ -10,7 +10,7 @@ export class MouseHandler extends InputAbstractHandler {
 		var identifier = 1;
 		this.onMouseDown = (e: MouseEvent) => {
 			if (e.button !== 0) return; // NOTE: 左クリック以外を受け付けない
-			this.pointDown(identifier, this.getOffsetPositionFromInputView(e.pageX, e.pageY));
+			this.pointDown(identifier, this.getOffsetPositionFromInputView(e));
 			window.addEventListener("mousemove", this.onMouseMove, false);
 			window.addEventListener("mouseup", this.onMouseUp, false);
 			if (!this._disablePreventDefault) {
@@ -19,14 +19,14 @@ export class MouseHandler extends InputAbstractHandler {
 			}
 		};
 		this.onMouseMove = (e: MouseEvent) => {
-			this.pointMove(identifier, this.getOffsetPositionFromInputView(e.pageX, e.pageY));
+			this.pointMove(identifier, this.getOffsetPositionFromInputView(e));
 			if (!this._disablePreventDefault) {
 				e.stopPropagation();
 				e.preventDefault();
 			}
 		};
 		this.onMouseUp = (e: MouseEvent) => {
-			this.pointUp(identifier, this.getOffsetPositionFromInputView(e.pageX, e.pageY));
+			this.pointUp(identifier, this.getOffsetPositionFromInputView(e));
 			window.removeEventListener("mousemove", this.onMouseMove, false);
 			window.removeEventListener("mouseup", this.onMouseUp, false);
 			if (!this._disablePreventDefault) {

--- a/src/handler/TouchHandler.ts
+++ b/src/handler/TouchHandler.ts
@@ -58,12 +58,6 @@ export class TouchHandler extends MouseHandler {
 	}
 
 	convertToPagePosition(e: Touch): OffsetPosition {
-		// windowの左上を0,0とした時のinputViewのoffsetを取得する
-		var bounding = this.inputView.getBoundingClientRect();
-		var scale = this.getScale();
-		return {
-			offsetX: (e.pageX - Math.round(window.pageXOffset + bounding.left)) / scale.x,
-			offsetY: (e.pageY - Math.round(window.pageYOffset + bounding.top)) / scale.y
-		};
+		return this.getOffsetPositionFromInputView(e.pageX, e.pageY);
 	}
 }

--- a/src/handler/TouchHandler.ts
+++ b/src/handler/TouchHandler.ts
@@ -1,5 +1,4 @@
 import { MouseHandler } from "./MouseHandler";
-import { OffsetPosition } from "./OffsetPosition";
 
 export class TouchHandler extends MouseHandler {
 	private onTouchDown: (e: TouchEvent) => void;
@@ -12,7 +11,7 @@ export class TouchHandler extends MouseHandler {
 			var touches = e.changedTouches;
 			for (var i = 0, len = touches.length; i < len; i++) {
 				var touch = touches[i];
-				this.pointDown(touch.identifier, this.convertToPagePosition(touch));
+				this.pointDown(touch.identifier, this.getOffsetPositionFromInputView(touch));
 			}
 			if (!this._disablePreventDefault) {
 				e.stopPropagation();
@@ -23,7 +22,7 @@ export class TouchHandler extends MouseHandler {
 			var touches = e.changedTouches;
 			for (var i = 0, len = touches.length; i < len; i++) {
 				var touch = touches[i];
-				this.pointMove(touch.identifier, this.convertToPagePosition(touch));
+				this.pointMove(touch.identifier, this.getOffsetPositionFromInputView(touch));
 			}
 			if (!this._disablePreventDefault) {
 				e.stopPropagation();
@@ -34,7 +33,7 @@ export class TouchHandler extends MouseHandler {
 			var touches = e.changedTouches;
 			for (var i = 0, len = touches.length; i < len; i++) {
 				var touch = touches[i];
-				this.pointUp(touch.identifier, this.convertToPagePosition(touch));
+				this.pointUp(touch.identifier, this.getOffsetPositionFromInputView(touch));
 			}
 			if (!this._disablePreventDefault) {
 				e.stopPropagation();
@@ -55,9 +54,5 @@ export class TouchHandler extends MouseHandler {
 		this.inputView.removeEventListener("touchstart", this.onTouchDown);
 		this.inputView.removeEventListener("touchmove", this.onTouchMove);
 		this.inputView.removeEventListener("touchend", this.onTouchUp);
-	}
-
-	convertToPagePosition(e: Touch): OffsetPosition {
-		return this.getOffsetPositionFromInputView(e.pageX, e.pageY);
 	}
 }


### PR DESCRIPTION
### 概要
* マウスが画面外に飛んだ場合pointMove等のイベントが強制的に終了されてしまう問題への対応を行いました。この対応によってマウス操作が画面外に飛んだ場合でもイベントが止まらずに継続されるようになります。

### やったこと
* InputAbstractHandlerにcanvasから見た相対的なoffsetを算出する`getOffsetPositionFromInputView()`を作成して、マウスイベントで座標取得のためにそのメソッドを使うように変更

### 確認事項
この変更を加えたpdi-broserを含むengine-filesで以下の確認を行いました。
* コンテンツ画面内でpointDownイベントを起こした後、画面外でもpointMoveやpointUpイベントが継続できること
* mouseHandlerと同様にtouchHandlerを用いても上記ができること