### PR TITLE
majorバージョンアップをrenovateの対象外にする対応

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,10 @@
     {
       "updateTypes": ["patch"],
       "groupName": "all dependencies"
+    },
+    {
+      "updateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### 概要
* pdi-browserでも基本的にはakashic-cliと同じように、renovateで行うバージョンアップはminorかpatchだけにしたいのでそのようにrenovate.jsonに修正を入れました。