### PR TITLE
move surface.destroy duty from Platform to ContainerController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.8.2
+* Platform#setRendererRequirement() を二度以上呼び出すと例外が発生する問題を修正
+
 ## 1.8.1
 * MouseHandler が画面外でキャンセルされてしまう問題を修正
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/ContainerController.ts
+++ b/src/ContainerController.ts
@@ -117,8 +117,10 @@ export class ContainerController {
 			// Note: 操作プラグインに与えた view 情報を削除しないため、 inputHandlerLayer を使いまわしている
 			this.inputHandlerLayer.setViewSize({ width, height });
 			this.inputHandlerLayer.pointEventTrigger.removeAll();
-			this.inputHandlerLayer.view.removeChild(this.surface.canvas);
-			this.surface.destroy();
+			if (this.surface && ! this.surface.destroyed()) {
+				this.inputHandlerLayer.view.removeChild(this.surface.canvas);
+				this.surface.destroy();
+			}
 		}
 
 		// 入力受け付けレイヤー > 描画レイヤー

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -124,8 +124,6 @@ export class Platform implements pdi.Platform {
 				this.containerController.pointEventTrigger.add(this._platformEventHandler.onPointEvent, this._platformEventHandler);
 			}
 		} else {
-			const surface = this.getPrimarySurface();
-			if (surface && ! surface.destroyed()) surface.destroy();
 			this.containerController.resetView(requirement);
 		}
 	}


### PR DESCRIPTION
## このPullRequestが解決する内容

`Platform#setRendererRequirement()` を2度呼び出したとき、2度目の処理でnull参照によって例外が発生します。
これを解決するため、primary surfaceの削除責務をPlatformからcontainerControllerに移します。