### PR TITLE
g.Glyphの利用箇所でg.GlyphLikeを使うよう差し替える対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.0-beta.3
+* `g.Glyph` が deprecated になったので、`g.GlyphLike` に置き換える対応
+
 ## 2.0.0-beta.2
 * 各AudioPlayerの `_calculateVolume()` の計算条件を `AudioPlayer#_muted` から `AudioSystem#_muted`へ変更
 * 未使用の `PostMessageAudioPlugin` 関連を削除

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@akashic/akashic-engine": {
-      "version": "3.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.0.0-beta.8.tgz",
-      "integrity": "sha512-TB+j0EgZn8zndcHQM20OBh2Gdif89opZxeU8qhNkuyiFr6kwStDfcsGRmy1YiAiZYUmGfvIuc4CIcWWmt6F0lQ==",
+      "version": "3.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.0.0-beta.13.tgz",
+      "integrity": "sha512-y0ciLe6swKj3sD447uivpEK0PXPyBaJpZe0y25xMkqWZvULxNRtm4WkCQgFNSVAgcmDX1frTYCAAU8HdUmfJCA==",
       "requires": {
         "@akashic/playlog": "~2.0.0",
         "@akashic/trigger": "~0.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",
@@ -63,7 +63,7 @@
     "uglify-js": "3.7.2"
   },
   "dependencies": {
-    "@akashic/akashic-engine": "~3.0.0-beta.8"
+    "@akashic/akashic-engine": "~3.0.0-beta.13"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/",

--- a/src/canvas/GlyphFactory.ts
+++ b/src/canvas/GlyphFactory.ts
@@ -157,6 +157,41 @@ function fontFamily2CSSFontFamily(fontFamily: g.FontFamily|string|(g.FontFamily|
 	}
 }
 
+function createGlyphLike(
+	code: number,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	offsetX: number = 0,
+	offsetY: number = 0,
+	advanceWidth: number = width,
+	surface?: g.SurfaceLike,
+	isSurfaceValid: boolean = !!surface
+): g.GlyphLike {
+	const _atlas: null = null;
+	const obj = {
+		code,
+		x,
+		y,
+		width,
+		height,
+		surface,
+		offsetX,
+		offsetY,
+		advanceWidth,
+		isSurfaceValid,
+		_atlas,
+		renderingWidth: (fontSize: number): number => {
+			if (!obj.width || !obj.height) {
+				return 0;
+			}
+			return (fontSize / obj.height) * obj.width;
+		}
+	};
+	return obj;
+}
+
 export class GlyphFactory extends g.GlyphFactory {
 	/**
 	 * 実行環境が描画可能な最小フォントサイズ
@@ -197,7 +232,7 @@ export class GlyphFactory extends g.GlyphFactory {
 		}
 	}
 
-	create(code: number): g.Glyph {
+	create(code: number): g.GlyphLike {
 		let result: GlyphRenderSurfaceResult;
 		let glyphArea = this._glyphAreas[code];
 
@@ -218,9 +253,9 @@ export class GlyphFactory extends g.GlyphFactory {
 			if (result) {
 				result.surface.destroy();
 			}
-			return new g.Glyph(code, 0, 0, 0, 0, 0, 0, glyphArea.advanceWidth, undefined, true);
+			return createGlyphLike(code, 0, 0, 0, 0, 0, 0, glyphArea.advanceWidth, undefined, true);
 		} else {
-			// g.Glyphに格納するサーフェスを生成する。
+			// g.GlyphLikeに格納するサーフェスを生成する。
 			// glyphAreaはサーフェスをキャッシュしないため、描画する内容を持つグリフに対しては
 			// サーフェスを生成する。もし前段でcalcGlyphArea()のためのサーフェスを生成して
 			// いればここでは生成せずにそれを利用する。
@@ -233,7 +268,7 @@ export class GlyphFactory extends g.GlyphFactory {
 					this.strokeColor, this.strokeOnly, this.fontWeight
 				);
 			}
-			return new g.Glyph(
+			return createGlyphLike(
 				code,
 				glyphArea.x, glyphArea.y,
 				glyphArea.width, glyphArea.height,

--- a/src/canvas/GlyphFactory.ts
+++ b/src/canvas/GlyphFactory.ts
@@ -167,7 +167,7 @@ function createGlyphLike(
 	offsetY: number = 0,
 	advanceWidth: number = width,
 	surface?: g.SurfaceLike,
-	isSurfaceValid: boolean = !!surface
+	isSurfaceValid?: boolean
 ): g.GlyphLike {
 	return {
 		code,

--- a/src/canvas/GlyphFactory.ts
+++ b/src/canvas/GlyphFactory.ts
@@ -157,7 +157,7 @@ function fontFamily2CSSFontFamily(fontFamily: g.FontFamily|string|(g.FontFamily|
 	}
 }
 
-function createGlyphLike(
+function createGlyph(
 	code: number,
 	x: number,
 	y: number,
@@ -245,7 +245,7 @@ export class GlyphFactory extends g.GlyphFactory {
 			if (result) {
 				result.surface.destroy();
 			}
-			return createGlyphLike(code, 0, 0, 0, 0, 0, 0, glyphArea.advanceWidth, undefined, true);
+			return createGlyph(code, 0, 0, 0, 0, 0, 0, glyphArea.advanceWidth, undefined, true);
 		} else {
 			// g.GlyphLikeに格納するサーフェスを生成する。
 			// glyphAreaはサーフェスをキャッシュしないため、描画する内容を持つグリフに対しては
@@ -260,7 +260,7 @@ export class GlyphFactory extends g.GlyphFactory {
 					this.strokeColor, this.strokeOnly, this.fontWeight
 				);
 			}
-			return createGlyphLike(
+			return createGlyph(
 				code,
 				glyphArea.x, glyphArea.y,
 				glyphArea.width, glyphArea.height,

--- a/src/canvas/GlyphFactory.ts
+++ b/src/canvas/GlyphFactory.ts
@@ -163,11 +163,11 @@ function createGlyph(
 	y: number,
 	width: number,
 	height: number,
-	offsetX: number = 0,
-	offsetY: number = 0,
-	advanceWidth: number = width,
-	surface?: g.SurfaceLike,
-	isSurfaceValid?: boolean
+	offsetX: number,
+	offsetY: number,
+	advanceWidth: number,
+	surface: g.SurfaceLike,
+	isSurfaceValid: boolean
 ): g.GlyphLike {
 	return {
 		code,

--- a/src/canvas/GlyphFactory.ts
+++ b/src/canvas/GlyphFactory.ts
@@ -169,8 +169,7 @@ function createGlyphLike(
 	surface?: g.SurfaceLike,
 	isSurfaceValid: boolean = !!surface
 ): g.GlyphLike {
-	const _atlas: null = null;
-	const obj = {
+	return {
 		code,
 		x,
 		y,
@@ -181,15 +180,8 @@ function createGlyphLike(
 		offsetY,
 		advanceWidth,
 		isSurfaceValid,
-		_atlas,
-		renderingWidth: (fontSize: number): number => {
-			if (!obj.width || !obj.height) {
-				return 0;
-			}
-			return (fontSize / obj.height) * obj.width;
-		}
+		_atlas: null
 	};
-	return obj;
 }
 
 export class GlyphFactory extends g.GlyphFactory {


### PR DESCRIPTION
### 概要
* https://github.com/akashic-games/akashic-engine/pull/189 の対応でg.Glyphがdeprecatedになるので、g.Glyphの代わりにg.GlyphLikeを使うようにする対応を行いました。