### PR TITLE
Fix array check in ShaderUniform.value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.10.1
+* シェーダの `uniform.value` で `Float32Array` が取得できない問題を修正
+
 ## 1.10.0
 * @akashic/amflowと@akashic/playlogのmajor更新に伴うバージョンアップ
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/canvas/webgl/WebGLShaderProgram.ts
+++ b/src/canvas/webgl/WebGLShaderProgram.ts
@@ -169,7 +169,7 @@ export class WebGLShaderProgram {
 		if (uniforms != null) {
 			Object.keys(uniforms).forEach(k => {
 				let type = uniforms[k].type;
-				const isArray = Array.isArray(uniforms[k].value);
+				const isArray = !(typeof uniforms[k].value === "number");
 				// typeがfloatまたはintで、valueが配列であれば配列としてuniform値を転送する。
 				if (isArray && (type === "int" || type === "float")) {
 					type += "_v";


### PR DESCRIPTION
## 概要

シェーダの `uniform.value` に `Float32Array` が渡された場合に取得できない不具合の修正。
配列チェックで `Array.isArray(value)` で判定していたが、`Array.isArray()` では TypedArray のインスタンスは常に false を返す仕様のため。
`ArrayBuffer.isView()` と `DataView` インスタンスを弾く条件でも可能だが、 `uniform.value` の型が `number | Int32Array | Float32Array` のため number 以外のチェックとする。
 
