### PR TITLE
Fix variable state with CanvasSurfaceContext#restore()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.0-beta.11
+* `CanvasSurfaceContext#restore()` で描画状態を復元された時に変数 `_currentXXXXX` が現在の状態を保持したままになる問題を修正
+
 ## 2.0.0-beta.10
 * @akashic/akashic-engine@3.0.0-beta.30 への追従対応
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 2.0.0-beta.11
-* `CanvasSurfaceContext#restore()` で描画状態を復元された時に変数 `_currentXXXXX` が現在の状態を保持したままになる問題を修正
+* `CanvasSurfaceContext#restore()` で描画状態を復元された時に変数 `_contextXXXXX` が現在の状態を保持したままになる問題を修正
 
 ## 2.0.0-beta.10
 * @akashic/akashic-engine@3.0.0-beta.30 への追従対応

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "An akashic-pdi implementatation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/canvas/context2d/CanvasSurfaceContext.ts
+++ b/src/canvas/context2d/CanvasSurfaceContext.ts
@@ -154,6 +154,9 @@ export class CanvasSurfaceContext {
 		}
 		this._stateStack.pop();
 		this._modifiedTransform = true;
+		this._currentFillStyle = this._context.fillStyle;
+		this._currentGlobalAlpha = this._context.globalAlpha;
+		this._currentGlobalCompositeOperation = this._context.globalCompositeOperation;
 	}
 
 	private currentState(): CanvasRenderingState {

--- a/src/canvas/context2d/CanvasSurfaceContext.ts
+++ b/src/canvas/context2d/CanvasSurfaceContext.ts
@@ -4,18 +4,18 @@ export class CanvasSurfaceContext {
 	protected _context: CanvasRenderingContext2D;
 	protected _stateStack: CanvasRenderingState[] = [];
 
-	protected _currentFillStyle: string | CanvasGradient | CanvasPattern;
-	protected _currentGlobalAlpha: number;
-	protected _currentGlobalCompositeOperation: string;
+	protected _contextFillStyle: string | CanvasGradient | CanvasPattern;
+	protected _contextGlobalAlpha: number;
+	protected _contextGlobalCompositeOperation: string;
 
 	private _modifiedTransform: boolean = false;
 
 	constructor(context: CanvasRenderingContext2D) {
 		this._context = context;
 		const state = new CanvasRenderingState();
-		this._currentFillStyle = state.fillStyle;
-		this._currentGlobalAlpha = state.globalAlpha;
-		this._currentGlobalCompositeOperation = state.globalCompositeOperation;
+		this._contextFillStyle = state.fillStyle;
+		this._contextGlobalAlpha = state.globalAlpha;
+		this._contextGlobalCompositeOperation = state.globalCompositeOperation;
 		this.pushState(state);
 	}
 
@@ -118,17 +118,17 @@ export class CanvasSurfaceContext {
 	prerender() {
 		const currentState = this.currentState();
 
-		if (currentState.fillStyle !== this._currentFillStyle) {
+		if (currentState.fillStyle !== this._contextFillStyle) {
 			this._context.fillStyle = currentState.fillStyle;
-			this._currentFillStyle = currentState.fillStyle;
+			this._contextFillStyle = currentState.fillStyle;
 		}
-		if (currentState.globalAlpha !== this._currentGlobalAlpha) {
+		if (currentState.globalAlpha !== this._contextGlobalAlpha) {
 			this._context.globalAlpha = currentState.globalAlpha;
-			this._currentGlobalAlpha = currentState.globalAlpha;
+			this._contextGlobalAlpha = currentState.globalAlpha;
 		}
-		if (currentState.globalCompositeOperation !== this._currentGlobalCompositeOperation) {
+		if (currentState.globalCompositeOperation !== this._contextGlobalCompositeOperation) {
 			this._context.globalCompositeOperation = currentState.globalCompositeOperation;
-			this._currentGlobalCompositeOperation = currentState.globalCompositeOperation;
+			this._contextGlobalCompositeOperation = currentState.globalCompositeOperation;
 		}
 		if (this._modifiedTransform) {
 			const transformer = currentState.transformer;
@@ -154,9 +154,10 @@ export class CanvasSurfaceContext {
 		}
 		this._stateStack.pop();
 		this._modifiedTransform = true;
-		this._currentFillStyle = this._context.fillStyle;
-		this._currentGlobalAlpha = this._context.globalAlpha;
-		this._currentGlobalCompositeOperation = this._context.globalCompositeOperation;
+		// TODO: `_context` が外部(Context2DRenderer)で破壊されているのでここで値を反映している。本来 `_context` の操作は全てこのクラスに集約すべきである。
+		this._contextFillStyle = this._context.fillStyle;
+		this._contextGlobalAlpha = this._context.globalAlpha;
+		this._contextGlobalCompositeOperation = this._context.globalCompositeOperation;
 	}
 
 	private currentState(): CanvasRenderingState {


### PR DESCRIPTION
## 概要

restore() により描画状態が復元されるが、 `CanvasSurfaceContext` のメンバ変数 `_currentfillStyle`, `_currentGlobalAlpha`, `_currentGlobalCompositeOperation` は現在の状態を保持したままになり `context` との状態が異なる問題を修正。

`_currentXXXXX` の変数名を `_contextXXXXX` へ変更
