### PR TITLE
fix: 未参照の CanvasSurface に関連付けられた HTMLCanvasElement を開放するように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## unreleased changes
+## 2.3.1
 * 参照されなくなった HTMLCanvasElement のメモリリークを検知して開放するように
 
 ## 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## unreleased changes
+* 参照されなくなった HTMLCanvasElement のメモリリークを検知して開放するように
+
 ## 2.3.0
 * @akashic/pdi-types@1.4.0 に追従
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "~1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/canvas/shims/CanvasDisposer.ts
+++ b/src/canvas/shims/CanvasDisposer.ts
@@ -7,7 +7,7 @@ export class CanvasDisposer {
 		this._registry = typeof FinalizationRegistry !== "undefined" ? new FinalizationRegistry(this._dispose.bind(this)) : null;
 	}
 
-	register(target: any, canvas: HTMLCanvasElement): void {
+	register(target: object, canvas: HTMLCanvasElement): void {
 		if (!this.register) return;
 		const id = `${this._idCounter++}`;
 		this._canvasMap[id] = canvas;

--- a/src/canvas/shims/CanvasDisposer.ts
+++ b/src/canvas/shims/CanvasDisposer.ts
@@ -1,17 +1,14 @@
 export class CanvasDisposer {
 	private _idCounter: number = 0;
 	private _canvasMap: {[id: string]: HTMLCanvasElement} = {};
-	private _registry: FinalizationRegistry<string>;
+	private _registry: FinalizationRegistry<string> | null; // FinalizationRegistry 非対応環境では null
 
 	constructor() {
-		// FIXME: PhantomJS の利用停止後に削除
-		if (typeof FinalizationRegistry === "undefined") {
-			return;
-		}
-		this._registry = new FinalizationRegistry(this._dispose.bind(this));
+		this._registry = typeof FinalizationRegistry !== "undefined" ? new FinalizationRegistry(this._dispose.bind(this)) : null;
 	}
 
 	register(target: any, canvas: HTMLCanvasElement): void {
+		if (!this.register) return;
 		const id = `${this._idCounter++}`;
 		this._canvasMap[id] = canvas;
 		this._registry.register(target, id);

--- a/src/canvas/shims/CanvasDisposer.ts
+++ b/src/canvas/shims/CanvasDisposer.ts
@@ -4,6 +4,10 @@ export class CanvasDisposer {
 	private _registry: FinalizationRegistry<string>;
 
 	constructor() {
+		// FIXME: PhantomJS の利用停止後に削除
+		if (typeof FinalizationRegistry === "undefined") {
+			return;
+		}
 		this._registry = new FinalizationRegistry(this._dispose.bind(this));
 	}
 

--- a/src/canvas/shims/CanvasDisposer.ts
+++ b/src/canvas/shims/CanvasDisposer.ts
@@ -1,0 +1,24 @@
+export class CanvasDisposer {
+	private _idCounter: number = 0;
+	private _canvasMap: {[id: string]: HTMLCanvasElement} = {};
+	private _registry: FinalizationRegistry<string>;
+
+	constructor() {
+		this._registry = new FinalizationRegistry(this._dispose.bind(this));
+	}
+
+	register(target: any, canvas: HTMLCanvasElement): void {
+		const id = `${this._idCounter++}`;
+		this._canvasMap[id] = canvas;
+		this._registry.register(target, id);
+	}
+
+	private _dispose(id: string): void {
+		const canvas = this._canvasMap[id];
+		if (!canvas) return;
+
+		canvas.width = 1;
+		canvas.height = 1;
+		delete this._canvasMap[id];
+	}
+}

--- a/src/canvas/shims/CanvasSurfaceFactory.ts
+++ b/src/canvas/shims/CanvasSurfaceFactory.ts
@@ -1,11 +1,16 @@
 import { Context2DSurface } from "../context2d/Context2DSurface";
+import { CanvasDisposer } from "./CanvasDisposer";
 
 export class SurfaceFactory {
+	_disposer: CanvasDisposer = new CanvasDisposer();
+
 	createPrimarySurface(width: number, height: number, _rendererCandidates?: string[]): Context2DSurface {
 		return new Context2DSurface(width, height);
 	}
 
 	createBackSurface(width: number, height: number, _rendererCandidates?: string[]): Context2DSurface {
-		return new Context2DSurface(width, height);
+		const surface = new Context2DSurface(width, height);
+		this._disposer.register(surface, surface.getHTMLElement() as HTMLCanvasElement);
+		return surface;
 	}
 }

--- a/src/canvas/shims/SurfaceFactory.ts
+++ b/src/canvas/shims/SurfaceFactory.ts
@@ -2,9 +2,11 @@ import type { CanvasSurface } from "../CanvasSurface";
 import { Context2DSurface } from "../context2d/Context2DSurface";
 import { RenderingHelper } from "../RenderingHelper";
 import { WebGLSharedObject } from "../webgl/WebGLSharedObject";
+import { CanvasDisposer } from "./CanvasDisposer";
 
 export class SurfaceFactory {
 	_shared: WebGLSharedObject;
+	_disposer: CanvasDisposer = new CanvasDisposer();
 
 	createPrimarySurface(width: number, height: number, rendererCandidates?: string[]): CanvasSurface {
 		if (RenderingHelper.usedWebGL(rendererCandidates)) {
@@ -18,10 +20,10 @@ export class SurfaceFactory {
 	}
 
 	createBackSurface(width: number, height: number, rendererCandidates?: string[]): CanvasSurface {
-		if (RenderingHelper.usedWebGL(rendererCandidates)) {
-			return this._shared.createBackSurface(width, height);
-		} else {
-			return new Context2DSurface(width, height);
-		}
+		const surface = RenderingHelper.usedWebGL(rendererCandidates)
+			? this._shared.createBackSurface(width, height)
+			: new Context2DSurface(width, height);
+		this._disposer.register(surface, surface.getHTMLElement() as HTMLCanvasElement);
+		return surface;
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "es5"],
+    "lib": ["dom", "ES2021"],
     "types": [],
     "noImplicitAny": true,
     "noImplicitThis": true,


### PR DESCRIPTION
# このPullRequestが解決する内容
参照されなくなった `CanvasSurface` を検知し、関連付けられた `HTMLCanvasElement` のメモリを開放するように修正します。

以下のミニマムコンテンツにて正常に dispose されていることを確認しています。

<details>
<summary>動作確認</summary>

* register, dispose 時にログを追加

```javascript
module.exports = () => {
  const scene = new g.Scene({
    game: g.game
  });

  scene.onLoad.add(() => {
    scene.onUpdate.add(() => {
      const surface = g.game.resourceFactory.createSurface(100, 100);
      const sprite = new g.Sprite({
        scene,
        src: surface,
        width: 32,
        height: 32
      });
      scene.append(sprite);

      scene.setTimeout(() => {
        sprite.destroy();
      }, 10);
    });
  });
  g.game.pushScene(scene);
}
```

![スクリーンショット 2022-09-07 14 17 02](https://user-images.githubusercontent.com/16933898/188794645-9caa236d-9bb8-4db9-92dc-a96ea6835272.png)

</details>