### PR TITLE
enable offset only systemId:sound

### DIFF
--- a/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
+++ b/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
@@ -47,15 +47,16 @@ export class WebAudioPlayer extends AudioPlayer {
 			// Chromeだとevent listerで指定した場合に動かないことがある
 			// https://github.com/mozilla-appmaker/appmaker/issues/1984
 			this._sourceNode.onended = this._endedEventHandler;
-			if (asset._system.id === "sound") {
-				if (asset.duration > 0) {
-					this._sourceNode.start(0, asset.duration / 2000, asset.duration / 1000);
-				} else {
-					this._sourceNode.start(0, asset.offset / 1000);
-				}
-			} else if (asset._system.id === "music") {
+			if (asset._system.id === "music") {
 				bufferNode.loop = asset.loop;
 				this._sourceNode.start(0);
+			} else {
+                const offset = (asset.offset ?? 0) / 1000;
+				if (asset.duration > 0) {
+					this._sourceNode.start(0, offset, asset.duration / 1000);
+				} else {
+					this._sourceNode.start(0, offset);
+				}
 			}
 		} else {
 			// 再生できるオーディオがない場合。duration後に停止処理だけ行う(処理のみ進め音は鳴らさない)

--- a/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
+++ b/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
@@ -40,7 +40,6 @@ export class WebAudioPlayer extends AudioPlayer {
 		}
 		if (asset.data) {
 			const bufferNode = helper.createBufferNode(this._audioContext);
-			bufferNode.loop = asset.loop;
 			bufferNode.buffer = asset.data;
 			this._gainNode.gain.value = this._calculateVolume();
 			bufferNode.connect(this._gainNode);
@@ -48,6 +47,17 @@ export class WebAudioPlayer extends AudioPlayer {
 			// Chromeだとevent listerで指定した場合に動かないことがある
 			// https://github.com/mozilla-appmaker/appmaker/issues/1984
 			this._sourceNode.onended = this._endedEventHandler;
+			if (asset._system.id === "sound") {
+				if (asset.duration > 0) {
+					this._sourceNode.start(0, asset.duration / 2000, asset.duration / 1000);
+				} else {
+					this._sourceNode.start(0, asset.offset / 1000);
+				}
+			} else if (asset._system.id === "music") {
+				bufferNode.loop = asset.loop;
+				this._sourceNode.start(0);
+			}
+
 			if (asset.duration > 0) {
 				this._sourceNode.start(0, asset.offset / 1000, asset.duration / 1000);
 			} else {

--- a/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
+++ b/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
@@ -47,7 +47,8 @@ export class WebAudioPlayer extends AudioPlayer {
 			// Chromeだとevent listerで指定した場合に動かないことがある
 			// https://github.com/mozilla-appmaker/appmaker/issues/1984
 			this._sourceNode.onended = this._endedEventHandler;
-			if (asset._system.id === "music") {
+			// loop時にoffsetを指定すると正しく動作しないことがあるため、暫定対応としてloopが真の場合はoffsetを指定しない
+			if (asset.loop) {
 				bufferNode.loop = asset.loop;
 				this._sourceNode.start(0);
 			} else {

--- a/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
+++ b/src/plugin/WebAudioPlugin/WebAudioPlayer.ts
@@ -57,12 +57,6 @@ export class WebAudioPlayer extends AudioPlayer {
 				bufferNode.loop = asset.loop;
 				this._sourceNode.start(0);
 			}
-
-			if (asset.duration > 0) {
-				this._sourceNode.start(0, asset.offset / 1000, asset.duration / 1000);
-			} else {
-				this._sourceNode.start(0, asset.offset / 1000);
-			}
 		} else {
 			// 再生できるオーディオがない場合。duration後に停止処理だけ行う(処理のみ進め音は鳴らさない)
 			this._dummyDurationWaitTimer = setTimeout(this._endedEventHandler, asset.duration);


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
オーディオアセットのループ機能を、 systemId が `sound` の場合のみ適用します。
同様に、 `AudioAsset#offset` による部分再生を `music` の場合のみ適用します。

関連： https://github.com/akashic-games/pdi-browser/pull/250

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

