### PR TITLE
feat: reintroduce mouse/touch event handler as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.7.1
+* `PointerEvent` 非サポート環境向けのフォールバック `MouseTouchEventHandler` を追加
+
 ## 2.7.0
 * BinaryAsset の実装を追加
 * `ScriptAsset#exports` に対応

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/ContainerController.ts
+++ b/src/ContainerController.ts
@@ -8,7 +8,7 @@ import type { ResourceFactory } from "./ResourceFactory";
 export interface ContainerControllerInitializeParameterObject {
 	rendererRequirement: pdi.RendererRequirement;
 	/**
-	 * NOTE: このオプションは後方互換性のために残している。現在のバージョンではこの値に関わらず一切の preventDefault() を行わない。
+	 * NOTE: このオプションは後方互換性のために残している。現在のバージョンではこの値は無視される。
 	 */
 	disablePreventDefault?: boolean;
 }

--- a/src/InputHandlerLayer.ts
+++ b/src/InputHandlerLayer.ts
@@ -1,5 +1,7 @@
 import type * as pdi from "@akashic/pdi-types";
 import { Trigger } from "@akashic/trigger";
+import type { InputEventHandler } from "./handler/InputEventHandler";
+import { MouseTouchEventHandler } from "./handler/MouseTouchEventHandler";
 import { PointerEventHandler } from "./handler/PointerEventHandler";
 
 export interface InputHandlerLayerParameterObject {
@@ -20,7 +22,7 @@ export class InputHandlerLayer {
 	// DOMで起きたイベントを通知するTrigger
 	pointEventTrigger: Trigger<pdi.PlatformPointEvent>;
 
-	_inputHandler: PointerEventHandler;
+	_inputHandler: InputEventHandler;
 
 	/**
 	 * @example
@@ -39,7 +41,9 @@ export class InputHandlerLayer {
 
 	// 実行環境でサポートしてるDOM Eventを使い、それぞれonPoint*Triggerを関連付ける
 	enablePointerEvent(): void {
-		this._inputHandler = new PointerEventHandler(this.view);
+		const pointerEventAvailable = !!window.PointerEvent;
+		this._inputHandler = pointerEventAvailable ? new PointerEventHandler(this.view) : new MouseTouchEventHandler(this.view);
+
 		// 各種イベントのTrigger
 		this._inputHandler.pointTrigger.add((e: pdi.PlatformPointEvent) => {
 			this.pointEventTrigger.fire(e);

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -23,15 +23,10 @@ export interface PlatformParameterObject {
 	containerView: HTMLElement;
 
 	/**
-	 * ビュー上のpreventDefaultを無効化するか。
-	 * デフォルトではpreventDefaultされるが、それを無効にしたい場合に指定すること。
+	 * 型の後方互換生のために残されている値。
 	 *
-	 * 注意: touchstartが利用可能な環境においてこの値を真にする場合、
-	 * 利用者はtouchstart, touchmove, touchendに対して自力で `preventDefault()` を呼び出さなくてはならない。
-	 * これはタッチとマウスの両方をサポートする環境に対応するために必要である。
-	 * `preventDefault()` が呼び出されない場合、Webブラウザはタッチイベントに対してマウスイベントを生成することがある。
-	 * この時pdi-browserは一度のタッチで二度pointDownの処理を行ってしまう。
-	 * 詳細は https://w3c.github.io/touch-events/#mouse-events を参照のこと。
+	 * 元々は、真を指定するとビュー上の MouseEvent/TouchEvent が preventDefault() されなくなるオプションだった。
+	 * 現在はこの値にかかわらず、(PointerEvent が利用できない環境で使われる) touchstart だけが preventDefault() される。
 	 */
 	disablePreventDefault?: boolean;
 

--- a/src/handler/InputEventHandler.ts
+++ b/src/handler/InputEventHandler.ts
@@ -1,0 +1,115 @@
+
+import type { CommonOffset, PlatformButtonType } from "@akashic/pdi-types";
+import { PlatformPointType, type PlatformPointEvent } from "@akashic/pdi-types";
+import { Trigger } from "@akashic/trigger";
+import type { OffsetPosition } from "./OffsetPosition";
+
+export interface Scale {
+	x: number;
+	y: number;
+}
+
+export interface PagePosition {
+	pageX: number;
+	pageY: number;
+}
+
+/**
+ * 入力ハンドラ。
+ *
+ * コンストラクタで受け取ったViewに対してのハンドラを設定する。
+ * DOMイベント情報から `PlatformPointEvent` へ変換したデータを `pointTrigger` を通して通知する。
+ * Down -> Move -> Up のフローにおける、Moveイベントのロックを管理する。
+ */
+export abstract class InputEventHandler {
+	inputView: HTMLElement;
+	pointTrigger: Trigger<PlatformPointEvent>;
+
+	protected _xScale: number;
+	protected _yScale: number;
+	// 移動中にdownなしでmoveやupを発生してしまうのを防ぐためのロック
+	protected pointerEventLock: { [key: number]: boolean };
+
+	// `start()` で設定するDOMイベントをサポートしているかを返す
+	static isSupported(): boolean {
+		return false;
+	}
+
+	constructor(inputView: HTMLElement) {
+		this.inputView = inputView;
+		this.pointerEventLock = {};
+		this._xScale = 1;
+		this._yScale = 1;
+		this.pointTrigger = new Trigger<PlatformPointEvent>();
+		inputView.style.touchAction = "none";
+		inputView.style.userSelect = "none";
+	}
+
+	abstract start(): void;
+	abstract stop(): void;
+
+	setScale(xScale: number, yScale: number = xScale): void {
+		this._xScale = xScale;
+		this._yScale = yScale;
+	}
+
+	pointDown(identifier: number, pagePosition: OffsetPosition, button: PlatformButtonType): void {
+		this.pointTrigger.fire({
+			type: PlatformPointType.Down,
+			identifier: identifier,
+			offset: this.getOffsetFromEvent(pagePosition),
+			button
+		});
+
+		// downのイベントIDを保存して、moveとupのイベントの抑制をする(ロックする)
+		this.pointerEventLock[identifier] = true;
+	}
+
+	pointMove(identifier: number, pagePosition: OffsetPosition, button: PlatformButtonType): void {
+		if (!this.pointerEventLock.hasOwnProperty(identifier + "")) {
+			return;
+		}
+		this.pointTrigger.fire({
+			type: PlatformPointType.Move,
+			identifier: identifier,
+			offset: this.getOffsetFromEvent(pagePosition),
+			button
+		});
+	}
+
+	pointUp(identifier: number, pagePosition: OffsetPosition, button: PlatformButtonType): void {
+		if (!this.pointerEventLock.hasOwnProperty(identifier + "")) {
+			return;
+		}
+		this.pointTrigger.fire({
+			type: PlatformPointType.Up,
+			identifier: identifier,
+			offset: this.getOffsetFromEvent(pagePosition),
+			button
+		});
+		// Upが完了したら、Down->Upが完了したとしてロックを外す
+		delete this.pointerEventLock[identifier];
+	}
+
+	getOffsetFromEvent(e: OffsetPosition): CommonOffset {
+		return { x: e.offsetX, y: e.offsetY };
+	}
+
+	getScale(): Scale {
+		return { x: this._xScale, y: this._yScale };
+	}
+
+	getOffsetPositionFromInputView(position: PagePosition): OffsetPosition {
+		// windowの左上を0,0とした時のinputViewのoffsetを取得する
+		const bounding = this.inputView.getBoundingClientRect();
+		const scale = this.getScale();
+		return {
+			offsetX: (position.pageX - Math.round(window.pageXOffset + bounding.left)) / scale.x,
+			offsetY: (position.pageY - Math.round(window.pageYOffset + bounding.top)) / scale.y
+		};
+	}
+}
+
+export function preventEventDefault(ev: Event): void {
+	ev.preventDefault();
+}

--- a/src/handler/InputEventHandler.ts
+++ b/src/handler/InputEventHandler.ts
@@ -1,4 +1,3 @@
-
 import type { CommonOffset, PlatformButtonType } from "@akashic/pdi-types";
 import { PlatformPointType, type PlatformPointEvent } from "@akashic/pdi-types";
 import { Trigger } from "@akashic/trigger";

--- a/src/handler/MouseTouchEventHandler.ts
+++ b/src/handler/MouseTouchEventHandler.ts
@@ -51,7 +51,7 @@ export class MouseTouchEventHandler extends InputEventHandler {
 
 	private onMouseDown: (e: MouseEvent) => void = e => {
 		// TODO ボタンが複数押される状態をサポートする
-		if (this.pressingMouseButton != null) return null;
+		if (this.pressingMouseButton != null) return;
 		this.pressingMouseButton = e.button;
 
 		this.pointDown(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));

--- a/src/handler/MouseTouchEventHandler.ts
+++ b/src/handler/MouseTouchEventHandler.ts
@@ -1,0 +1,99 @@
+import { PlatformButtonType } from "@akashic/pdi-types";
+import { InputEventHandler, preventEventDefault } from "./InputEventHandler";
+
+/**
+ * Mouse/Touch Events を利用した入力ハンドラ。
+ *
+ * Pointer Event が利用できない環境を想定するフォールバック実装。
+ * preventDefault() による副作用があるので、可能な環境では PointerEventHandler を利用すること。
+ */
+export class MouseTouchEventHandler extends InputEventHandler {
+	private static MOUSE_IDENTIFIER: number = 1;
+
+	// `start()` で設定するDOMイベントをサポートしているかを返す
+	static isSupported(): boolean {
+		return false;
+	}
+
+	start(): void {
+		this.inputView.addEventListener("mousedown", this.onMouseDown, false);
+		this.inputView.addEventListener("touchstart", this.onTouchStart);
+		this.inputView.addEventListener("touchmove", this.onTouchMove);
+		this.inputView.addEventListener("touchend", this.onTouchEnd);
+		this.inputView.addEventListener("contextmenu", preventEventDefault);
+	}
+
+	stop(): void {
+		this.inputView.removeEventListener("mousedown", this.onMouseDown, false);
+		this.inputView.removeEventListener("touchstart", this.onTouchStart);
+		this.inputView.removeEventListener("touchmove", this.onTouchMove);
+		this.inputView.removeEventListener("touchend", this.onTouchEnd);
+		this.inputView.removeEventListener("contextmenu", preventEventDefault);
+	}
+
+	private getPlatformButtonType(e: MouseEvent): PlatformButtonType {
+		switch (e.button) {
+			case 0:
+				// 左クリック
+				return PlatformButtonType.Primary;
+			case 1:
+				// ミドルクリック
+				return PlatformButtonType.Auxiliary;
+			case 2:
+				// 右クリック
+				return PlatformButtonType.Secondary;
+			default:
+				// 上記以外のボタンは左クリックとして扱う
+				return PlatformButtonType.Primary;
+		}
+	}
+
+	private onMouseDown: (e: MouseEvent) => void = e => {
+		this.pointDown(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
+		window.addEventListener("mousemove", this.onWindowMouseMove, false);
+		window.addEventListener("mouseup", this.onWindowMouseUp, false);
+		// NOTE ここで e.preventDefault() してはならない。
+		// preventDefault() すると、iframe 内で動作していて iframe 外にドラッグした時に mousemove が途切れるようになる。
+	};
+
+	private onWindowMouseMove: (e: MouseEvent) => void = e => {
+		this.pointMove(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
+	};
+
+	private onWindowMouseUp: (e: MouseEvent) => void = e => {
+		this.pointUp(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
+		window.removeEventListener("mousemove", this.onWindowMouseMove, false);
+		window.removeEventListener("mouseup", this.onWindowMouseUp, false);
+	};
+
+	private onTouchStart: (e: TouchEvent) => void = e => {
+		const touches = e.changedTouches;
+		for (let i = 0, len = touches.length; i < len; i++) {
+			const touch = touches[i];
+			this.pointDown(touch.identifier, this.getOffsetPositionFromInputView(touch), PlatformButtonType.Primary);
+		}
+
+		// NOTE touch に追従して発生する mouse イベントを抑止するために preventDefault() する。
+		// ref. https://w3c.github.io/touch-events/#mouse-events
+		// なおこの preventDefault() は iOS WebView では別の副作用を持つ: このクラスは iOS では利用すべきでない。
+		e.preventDefault();
+	};
+
+	private onTouchMove: (e: TouchEvent) => void = e => {
+		const touches = e.changedTouches;
+		for (let i = 0, len = touches.length; i < len; i++) {
+			const touch = touches[i];
+			this.pointMove(touch.identifier, this.getOffsetPositionFromInputView(touch), PlatformButtonType.Primary);
+		}
+	};
+
+	private onTouchEnd: (e: TouchEvent) => void = e => {
+		const touches = e.changedTouches;
+		for (let i = 0, len = touches.length; i < len; i++) {
+			const touch = touches[i];
+			this.pointUp(touch.identifier, this.getOffsetPositionFromInputView(touch), PlatformButtonType.Primary);
+		}
+		window.removeEventListener("touchmove", this.onTouchMove, false);
+		window.removeEventListener("touchend", this.onTouchEnd, false);
+	};
+}

--- a/src/handler/MouseTouchEventHandler.ts
+++ b/src/handler/MouseTouchEventHandler.ts
@@ -9,6 +9,7 @@ import { InputEventHandler, preventEventDefault } from "./InputEventHandler";
  */
 export class MouseTouchEventHandler extends InputEventHandler {
 	private static MOUSE_IDENTIFIER: number = 1;
+	private pressingMouseButton: number | null = null;
 
 	// `start()` で設定するDOMイベントをサポートしているかを返す
 	static isSupported(): boolean {
@@ -49,6 +50,10 @@ export class MouseTouchEventHandler extends InputEventHandler {
 	}
 
 	private onMouseDown: (e: MouseEvent) => void = e => {
+		// TODO ボタンが複数押される状態をサポートする
+		if (this.pressingMouseButton != null) return null;
+		this.pressingMouseButton = e.button;
+
 		this.pointDown(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
 		window.addEventListener("mousemove", this.onWindowMouseMove, false);
 		window.addEventListener("mouseup", this.onWindowMouseUp, false);
@@ -61,6 +66,9 @@ export class MouseTouchEventHandler extends InputEventHandler {
 	};
 
 	private onWindowMouseUp: (e: MouseEvent) => void = e => {
+		if (this.pressingMouseButton !== e.button) return;
+		this.pressingMouseButton = null;
+
 		this.pointUp(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
 		window.removeEventListener("mousemove", this.onWindowMouseMove, false);
 		window.removeEventListener("mouseup", this.onWindowMouseUp, false);

--- a/src/handler/PointerEventHandler.ts
+++ b/src/handler/PointerEventHandler.ts
@@ -1,18 +1,5 @@
-import type { CommonOffset, PlatformPointEvent } from "@akashic/pdi-types";
 import { PlatformButtonType } from "@akashic/pdi-types";
-import { PlatformPointType } from "@akashic/pdi-types";
-import { Trigger } from "@akashic/trigger";
-import type { OffsetPosition } from "./OffsetPosition";
-
-export interface Scale {
-	x: number;
-	y: number;
-}
-
-export interface PagePosition {
-	pageX: number;
-	pageY: number;
-}
+import { InputEventHandler, preventEventDefault } from "./InputEventHandler";
 
 type EventHandler = (event: PointerEvent) => void;
 
@@ -24,20 +11,13 @@ type EventHandlersMap = {
 };
 
 /**
- * pointer-events を利用した入力ハンドラ。
+ * Pointer Events を利用した入力ハンドラ。
  *
- * コンストラクタで受け取ったViewに対して pointer-events のハンドラを設定する。
+ * コンストラクタで受け取ったViewに対して Pointer Events のハンドラを設定する。
  * DOMイベント情報から `PlatformPointEvent` へ変換したデータを `pointTrigger` を通して通知する。
  * Down -> Move -> Up のフローにおける、Moveイベントのロックを管理する。
  */
-export class PointerEventHandler {
-	inputView: HTMLElement;
-	pointTrigger: Trigger<PlatformPointEvent>;
-
-	private _xScale: number;
-	private _yScale: number;
-	// 移動中にdownなしでmoveやupを発生してしまうのを防ぐためのロック
-	private pointerEventLock: { [key: number]: boolean };
+export class PointerEventHandler extends InputEventHandler {
 	// pointerId ごとのハンドラのマップ情報
 	private _eventHandlersMap: EventHandlersMap;
 
@@ -47,85 +27,18 @@ export class PointerEventHandler {
 	}
 
 	constructor(inputView: HTMLElement) {
-		this.inputView = inputView;
-		this.pointerEventLock = {};
+		super(inputView);
 		this._eventHandlersMap = Object.create(null);
-		this._xScale = 1;
-		this._yScale = 1;
-		this.pointTrigger = new Trigger<PlatformPointEvent>();
-		inputView.style.touchAction = "none";
-		inputView.style.userSelect = "none";
 	}
 
 	start(): void {
 		this.inputView.addEventListener("pointerdown", this.onPointerDown, false);
-		this.inputView.addEventListener("contextmenu", this.onContextMenu, false);
+		this.inputView.addEventListener("contextmenu", preventEventDefault, false);
 	}
 
 	stop(): void {
 		this.inputView.removeEventListener("pointerdown", this.onPointerDown, false);
-		this.inputView.removeEventListener("contextmenu", this.onContextMenu, false);
-	}
-
-	setScale(xScale: number, yScale: number = xScale): void {
-		this._xScale = xScale;
-		this._yScale = yScale;
-	}
-
-	pointDown(identifier: number, pagePosition: OffsetPosition, button: PlatformButtonType): void {
-		this.pointTrigger.fire({
-			type: PlatformPointType.Down,
-			identifier: identifier,
-			offset: this.getOffsetFromEvent(pagePosition),
-			button
-		});
-
-		// downのイベントIDを保存して、moveとupのイベントの抑制をする(ロックする)
-		this.pointerEventLock[identifier] = true;
-	}
-
-	pointMove(identifier: number, pagePosition: OffsetPosition, button: PlatformButtonType): void {
-		if (!this.pointerEventLock.hasOwnProperty(identifier + "")) {
-			return;
-		}
-		this.pointTrigger.fire({
-			type: PlatformPointType.Move,
-			identifier: identifier,
-			offset: this.getOffsetFromEvent(pagePosition),
-			button
-		});
-	}
-
-	pointUp(identifier: number, pagePosition: OffsetPosition, button: PlatformButtonType): void {
-		if (!this.pointerEventLock.hasOwnProperty(identifier + "")) {
-			return;
-		}
-		this.pointTrigger.fire({
-			type: PlatformPointType.Up,
-			identifier: identifier,
-			offset: this.getOffsetFromEvent(pagePosition),
-			button
-		});
-		// Upが完了したら、Down->Upが完了したとしてロックを外す
-		delete this.pointerEventLock[identifier];
-	}
-
-	getOffsetFromEvent(e: OffsetPosition): CommonOffset {
-		return { x: e.offsetX, y: e.offsetY };
-	}
-
-	getScale(): Scale {
-		return { x: this._xScale, y: this._yScale };
-	}
-
-	getOffsetPositionFromInputView(position: PagePosition): OffsetPosition {
-		// windowの左上を0,0とした時のinputViewのoffsetを取得する
-		const bounding = this.inputView.getBoundingClientRect();
-		const scale = this.getScale();
-		return {
-			offsetX: (position.pageX - Math.round(window.pageXOffset + bounding.left)) / scale.x,
-			offsetY: (position.pageY - Math.round(window.pageYOffset + bounding.top)) / scale.y
-		};
+		this.inputView.removeEventListener("contextmenu", preventEventDefault, false);
 	}
 
 	private getPlatformButtonType(e: PointerEvent): PlatformButtonType {
@@ -166,9 +79,5 @@ export class PointerEventHandler {
 		window.addEventListener("pointermove", onPointerMove, false);
 		window.addEventListener("pointerup", onPointerUp, false);
 		this._eventHandlersMap[e.pointerId] = { onPointerMove, onPointerUp };
-	};
-
-	private onContextMenu: (ev: Event) => void = (ev: Event) => {
-		ev.preventDefault();
 	};
 }

--- a/src/handler/__tests__/InputEventHandler.spec.ts
+++ b/src/handler/__tests__/InputEventHandler.spec.ts
@@ -1,12 +1,22 @@
 import { PlatformPointType, PlatformButtonType } from "@akashic/pdi-types";
-import { PointerEventHandler } from "../PointerEventHandler";
+import { InputEventHandler } from "../InputEventHandler";
 
-describe("PointerEventHandler", () => {
+// テスト用に abstract メソッドを補っただけの InputEventHandler
+class TestInputEventHandler extends InputEventHandler {
+	start(): void {
+		// do nothing
+	}
+	stop(): void {
+		// do nothing
+	}
+}
+
+describe("InputEventHandler", () => {
 	describe("DownのDOMイベントが発生済みの時", () => {
-		let handler: PointerEventHandler;
+		let handler: InputEventHandler;
 		let identifier: number;
 		beforeEach(() => {
-			handler = new PointerEventHandler(document.createElement("div"));
+			handler = new TestInputEventHandler(document.createElement("div"));
 			identifier = 1;
 			handler.pointDown(identifier, {offsetX: 1, offsetY: 1}, PlatformButtonType.Primary);
 		});
@@ -58,7 +68,7 @@ describe("PointerEventHandler", () => {
 	});
 	describe("DownのDOMイベントが起きていない時", () => {
 		it("DownのDOMイベントがあればonPointDownが呼ばれる", (done) => {
-			const handler = new PointerEventHandler(document.createElement("div"));
+			const handler = new TestInputEventHandler(document.createElement("div"));
 			handler.pointTrigger.add((object) => {
 				expect(object.type).toBe(PlatformPointType.Down);
 				expect(object.identifier).toBe(1);
@@ -72,7 +82,7 @@ describe("PointerEventHandler", () => {
 			handler.pointDown(1, {offsetX: 10, offsetY: 10}, PlatformButtonType.Secondary);
 		});
 		it("MoveのDOMイベントあってもonPointMoveは呼び出されない", (done) => {
-			const handler = new PointerEventHandler(document.createElement("div"));
+			const handler = new TestInputEventHandler(document.createElement("div"));
 			handler.pointMove(1, {offsetX: 0, offsetY: 0}, PlatformButtonType.Primary);
 			handler.pointTrigger.add(() => {
 				done.fail(new Error("not call!"));


### PR DESCRIPTION
掲題どおり。

`PointerEventHandler` が依存する PointerEvent が利用できない環境のため、フォールバックとして MouseEvent/TouchEvent を使う`MouseTouchEventHandler` を追加します。

- `PointerEventHandler` の PointerEvent に関連しない部分を `InputEventHandler` として切り出し
- `InputEventHandler` の派生クラスとして `MouseTouchEventHandler` を追加

ビルドした結果を engine-files に取り込んで akashic serve で動かして、デバッガで強制的に `MouseTouchEventHandler` を利用させることで、mouse/touch 両ハンドラが妥当な座標の `g.PointEvent` を生成してくることを確認しています。
