### PR TITLE
fix: `MouseTouchEventHandler` において `button` の値が一部 `PointerEventHandler` と異なってしまう問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## unreleased changes
+* `MouseTouchEventHandler` において `button` の値が一部 `PointerEventHandler` と異なってしまう問題を修正
+
 ## 2.8.2
 * `Platform#getTabindex()` を `Platform#getTabIndex()` に変更
 * `Platform#setTabindex()` を `Platform#setTabIndex()` に変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## unreleased changes
+## 2.8.3
 * `MouseTouchEventHandler` において `button` の値が一部 `PointerEventHandler` と異なってしまう問題を修正
 
 ## 2.8.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/handler/MouseTouchEventHandler.ts
+++ b/src/handler/MouseTouchEventHandler.ts
@@ -32,20 +32,22 @@ export class MouseTouchEventHandler extends InputEventHandler {
 		this.inputView.removeEventListener("contextmenu", preventEventDefault);
 	}
 
-	private getPlatformButtonType(e: MouseEvent): PlatformButtonType {
+	private getPlatformButtonType(e: MouseEvent, defaultValue: number): PlatformButtonType {
 		switch (e.button) {
+			case -1:
+				// 変化なし
+				return PlatformButtonType.Unchanged;
 			case 0:
-				// 左クリック
+				// 主ボタン（通常は左ボタン）
 				return PlatformButtonType.Primary;
 			case 1:
-				// ミドルクリック
+				// 予備ボタン（通常は中ボタン）
 				return PlatformButtonType.Auxiliary;
 			case 2:
-				// 右クリック
+				// 副ボタン（通常は右ボタン）
 				return PlatformButtonType.Secondary;
 			default:
-				// 上記以外のボタンは左クリックとして扱う
-				return PlatformButtonType.Primary;
+				return defaultValue;
 		}
 	}
 
@@ -54,7 +56,11 @@ export class MouseTouchEventHandler extends InputEventHandler {
 		if (this.pressingMouseButton != null) return;
 		this.pressingMouseButton = e.button;
 
-		this.pointDown(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
+		this.pointDown(
+			MouseTouchEventHandler.MOUSE_IDENTIFIER,
+			this.getOffsetPositionFromInputView(e),
+			this.getPlatformButtonType(e, PlatformButtonType.Primary)
+		);
 		window.addEventListener("mousemove", this.onWindowMouseMove, false);
 		window.addEventListener("mouseup", this.onWindowMouseUp, false);
 		// NOTE ここで e.preventDefault() してはならない。
@@ -62,14 +68,22 @@ export class MouseTouchEventHandler extends InputEventHandler {
 	};
 
 	private onWindowMouseMove: (e: MouseEvent) => void = e => {
-		this.pointMove(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
+		this.pointMove(
+			MouseTouchEventHandler.MOUSE_IDENTIFIER,
+			this.getOffsetPositionFromInputView(e),
+			PlatformButtonType.Unchanged // NOTE: 簡易的だが pointermove と挙動を揃えるために常に Unchanged を指定する
+		);
 	};
 
 	private onWindowMouseUp: (e: MouseEvent) => void = e => {
 		if (this.pressingMouseButton !== e.button) return;
 		this.pressingMouseButton = null;
 
-		this.pointUp(MouseTouchEventHandler.MOUSE_IDENTIFIER, this.getOffsetPositionFromInputView(e), this.getPlatformButtonType(e));
+		this.pointUp(
+			MouseTouchEventHandler.MOUSE_IDENTIFIER,
+			this.getOffsetPositionFromInputView(e),
+			this.getPlatformButtonType(e, PlatformButtonType.Primary)
+		);
 		window.removeEventListener("mousemove", this.onWindowMouseMove, false);
 		window.removeEventListener("mouseup", this.onWindowMouseUp, false);
 	};


### PR DESCRIPTION
# このPullRequestが解決する内容

`MouseTouchEventHandler` において `button` の値が一部 `PointerEventHandler` と異なってしまう問題を修正します。

## 挙動の違い

1. マウス左ボタンを押下
1. カーソルを移動
1. マウス左ボタンを離す

という一連の動作において、修正前と修正後の挙動の差異を簡易的な時系列として以下の表にまとめます。

## 修正前

| イベント種別 | `button` の値 | 動作 |
| -- | :--: | -- |
|`PointDownEvent`| 0  | マウス左ボタン押下 |
|`PointMoveEvent`| **0** | カーソル移動 |
|`PointMoveEvent`| **0** | カーソル移動 |
| ...            | .. | ... |
|`PointMoveEvent`| **0** | カーソル移動 |
|`PointUpEvent`  | 0  | マウス左ボタン離す |

## 修正後

| イベント種別 | `button` の値 | 動作 |
| -- | :--: | -- |
|`PointDownEvent`| 0  | マウス左ボタン押下 |
|`PointMoveEvent`| **-1** | カーソル移動 |
|`PointMoveEvent`| **-1** | カーソル移動 |
| ...            | .. | ... |
|`PointMoveEvent`| **-1** | カーソル移動 |
|`PointUpEvent`  | 0  | マウス左ボタン離す |

## `PointerEventHandler` との挙動の違い

<details>
<summary>中身を展開</summary>

また、 `PointerEventHandler` と `MouseTouchEventHandler` でそれぞれの挙動を比較しています。

1. マウス左ボタンを押下
1. カーソルを移動
1. マウス右ボタンを押下
1. マウス左ボタンを離す
1. カーソルを移動
1. マウス右ボタンを離す

という一連の動作について、それぞれの挙動の差異は以下の表のようになります。

### `PointerEventHandler`

| イベント種別 | `button` の値 | 動作 |
| -- | :--: | -- |
|`PointDownEvent`| 0  | マウス左ボタン押下 |
|`PointMoveEvent`| -1 | カーソル移動 |
|`PointMoveEvent`| -1 | カーソル移動 |
| ...            | .. | ... |
|`PointMoveEvent`| -1 | カーソル移動 |
|`PointMoveEvent`| 2  | マウス右ボタン押下 |
|`PointMoveEvent`| 0  | マウス左ボタン離す |
|`PointMoveEvent`| -1 | カーソル移動 |
| ...            | .. | ... |
|`PointMoveEvent`| -1 | カーソル移動 |
|`PointUpEvent`  | 2  | マウス右ボタン離す |

### `MouseTouchEventHandler`

| イベント種別 | `button` の値 | 動作 |
| -- | :--: | -- |
|`PointDownEvent`| 0  | マウス左ボタン押下 |
|`PointMoveEvent`| -1 | カーソル移動 |
|`PointMoveEvent`| -1 | カーソル移動 |
| ...            | .. | ... |
|`PointMoveEvent`| -1 | カーソル移動 |
|`PointUpEvent`  | 0  | マウス右ボタン押下 (この時点で `PointEvent` 一連の動作が中断) |

`MouseTouchEventHandler` の場合、マウスカーソルのドラッグ中に別のボタンを押下した際に一連の `PointEvent` の動作が中断されます。
これは `MouseTouchEventHandler` が内部的には (マイウスデバイスの場合) `mousedown`, `mousemove`, `mouseup` イベントをハンドラしているために生じています。

ただし `MouseTouchEventHandler` は [`PointerEvent`](https://developer.mozilla.org/ja/docs/Web/API/PointerEvent) が利用できない環境でのフォールバック機構であり、多くのケース (環境) では `PointerEventHandler` が利用されます。

したがって本 PullRequest ではこの挙動については特に修正をしていません。

</details>