### PR TITLE
fix: fix dragging by digitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.8.4
+* ペンタブレットによるドラッグ時、意図しない操作が起きる問題を修正
+
 ## 2.8.3
 * `MouseTouchEventHandler` において `button` の値が一部 `PointerEventHandler` と異なってしまう問題を修正
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/InputHandlerLayer.ts
+++ b/src/InputHandlerLayer.ts
@@ -74,7 +74,7 @@ export class InputHandlerLayer {
 
 	private _createInputView(width: number, height: number): HTMLDivElement {
 		const view = document.createElement("div");
-		view.setAttribute("style", "display:inline-block; outline:none;");
+		view.setAttribute("style", "display:inline-block; outline:none; touch-action:none");
 		view.style.width = width + "px";
 		view.style.height = height + "px";
 		view.setAttribute("tabindex", "0");


### PR DESCRIPTION
掲題どおり。 

ある種の環境でペンタブレットでゲーム画面をドラッグした際、ブラウザウィンドウ全体のスクロールなど (いわゆる direct manipulation) が起きるのを抑止します。これは akashic serve などでは再現しませんが、[ドラッグを使うサンプルデモ](https://akashic-games.github.io/demo/?title=point-event-button) で以下の条件で確認できます。

- Windows の Chrome や Firefox を使用している
- ワコムのタブレットを使用している
- ワコムのタブレット設定の「Windows Ink を使う」が有効になっている
- ブラウザウィンドウが狭い (スクロールできる状態)

ただし上のデモは pdi-browser を使っておらず、この PR 自体では修正されません。(ブラウザの開発者ツールで、この PR と同じように `touch-action` をつけて問題を解消することを目視しています)

akashic serve に組み込み、以下の環境で意図しない影響が出ないことを確認しています。
 - Mac Chrome 上の akashic serve
 - Mac Chrome (Device Mode) 上の akashic serve
