### PR TITLE
loop check with setTimeout

### DIFF
--- a/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
+++ b/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
@@ -52,15 +52,27 @@ export class HTMLAudioPlayer extends AudioPlayer {
 					});
 				}
 				if (end != null) {
+					const onEnded: () => void = () => {
+						if (asset.loop) {
+							audio.currentTime = loopStart;
+						} else {
+							audio.pause();
+						}
+					};
+					const setTimer = function(): void {
+						setTimeout(() => {
+							onEnded();
+							setTimer();
+						}, (end - loopStart) * 1000);
+					};
+					// timeupdate イベント通知の精度が低いため、 setTimeout と併用する
+					// addEventListener は裏タブ時にも動作させるため残す
 					audio.addEventListener("timeupdate", () => {
 						if (end <= audio.currentTime) {
-							if (asset.loop) {
-								audio.currentTime = loopStart;
-							} else {
-								audio.pause();
-							}
+							onEnded();
 						}
 					});
+					setTimer();
 				}
 			}
 


### PR DESCRIPTION
## このpull requestが解決する内容

HTMLAudioのループチェックは精度が低いことがあるため、これを改善します。
参考: https://developer.mozilla.org/ja/docs/Web/API/HTMLMediaElement/timeupdate_event

setTimeoutを利用しtimeupdateよりも高精度でループすべき時間を判定しつつ、
timeupdateと併用することで非アクティブウインドウ時にもループの動作を保証できるようにします。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

