### PR TITLE
skip super.stop when loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.10.1
+* `HTMLAudioPlayer` でループ再生時に停止できなくなる不具合を修正
+
 ## 2.10.0
 * @akashic/pdi-types@1.14.0 に更新
 * `RendererCandidate` をサポート

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
+++ b/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
@@ -12,6 +12,7 @@ export class HTMLAudioPlayer extends AudioPlayer {
 	private _isStopRequested: boolean = false;
 	private _onPlayEventHandler: () => void;
 	private _dummyDurationWaitTimer: any;
+	private _assetLoop: boolean = false;
 
 	constructor(system: pdi.AudioSystem, manager: AudioManager) {
 		super(system);
@@ -30,6 +31,7 @@ export class HTMLAudioPlayer extends AudioPlayer {
 			this.stop();
 		}
 		const audio = asset.cloneElement();
+		this._assetLoop = asset.loop;
 
 		if (audio) {
 			if (!asset.offset) {
@@ -111,8 +113,10 @@ export class HTMLAudioPlayer extends AudioPlayer {
 	}
 
 	private _onAudioEnded(): void {
-		this._clearEndedEventHandler();
-		super.stop();
+		if (!this._assetLoop) {
+			this._clearEndedEventHandler();
+			super.stop();
+		}
 	}
 
 	private _clearEndedEventHandler(): void {


### PR DESCRIPTION
## このpull requestが解決する内容

offset+duration の値が音声の長さを上回るオーディオアセットをループ再生した場合、
2週目以降はオーディオを停止できなくなる現象を修正します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

