### PR TITLE
Fix htmlaudioplayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.9.2
+* `HTMLAudioPlayer#play()` で同じ audio が連続で再生された時にエラーとなる不具合を修正
+
 ## 2.9.1
 * View の外をクリック時に `pointDown` イベントが発生しないよう修正
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
+++ b/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
@@ -31,7 +31,7 @@ export class HTMLAudioPlayer extends AudioPlayer {
 				// 同じ audio を 連続で再生するとエラーとなる。これは audio.play() が非同期で開始されるためである。
 				// 現在再生中とこれから再生しようとする audio が同じ場合は現在の audio を先頭から再生し、これから再生しようとする audio は何もしないようにする。
 				super.stop();
-				this._audioInstance!.currentTime = 0;
+				this._audioInstance!.currentTime = (asset.offset ?? 0) / 1000;
 				super.play(asset);
 				return;
 			}

--- a/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
+++ b/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
@@ -28,13 +28,13 @@ export class HTMLAudioPlayer extends AudioPlayer {
 	play(asset: HTMLAudioAsset): void {
 		if (this.currentAudio) {
 			if (asset.id === this.currentAudio.id) {
-				// 同一 audio を 連続で再生処理を行うとエラーとなる。これは audio.play() が非同期で開始されるためである。
-				// 上記対応で、現在再生中とこれから再生する audio が同じ場合は現在の audio を先頭から再生し、これから再生する audio は何もしないようにする。
+				// 同じ audio を 連続で再生するとエラーとなる。これは audio.play() が非同期で開始されるためである。
+				// 現在再生中とこれから再生しようとする audio が同じ場合は現在の audio を先頭から再生し、これから再生しようとする audio は何もしないようにする。
 				super.stop();
 				this._audioInstance!.currentTime = 0;
 				super.play(asset);
 				return;
-			  }
+			}
 			this.stop();
 		}
 		const audio = asset.cloneElement();

--- a/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
+++ b/src/plugin/HTMLAudioPlugin/HTMLAudioPlayer.ts
@@ -27,6 +27,14 @@ export class HTMLAudioPlayer extends AudioPlayer {
 
 	play(asset: HTMLAudioAsset): void {
 		if (this.currentAudio) {
+			if (asset.id === this.currentAudio.id) {
+				// 同一 audio を 連続で再生処理を行うとエラーとなる。これは audio.play() が非同期で開始されるためである。
+				// 上記対応で、現在再生中とこれから再生する audio が同じ場合は現在の audio を先頭から再生し、これから再生する audio は何もしないようにする。
+				super.stop();
+				this._audioInstance!.currentTime = 0;
+				super.play(asset);
+				return;
+			  }
 			this.stop();
 		}
 		const audio = asset.cloneElement();


### PR DESCRIPTION
## 概要

`HTMLAudioPlayer#play()` で同一の audio を連続するとエラーとなる問題を修正。
現在再生中の audio とこれから再生する audio が同じ場合は、現在再生中の audio を先頭から再生し、再生する予定の audio は何もしないように修正。
