### PR TITLE
[WIP]Support pointercancel touchcancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.11.0-beta.0
+* `PointerEventHandler` に `pointercancel` を追加。
+* `MouseTouchEventHandler` に `touchcancel` を追加。
+
 ## 2.10.0
 * @akashic/pdi-types@1.14.0 に更新
 * `RendererCandidate` をサポート

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 2.11.0-beta.0
+## 2.11.0
 * `PointerEventHandler` に `pointercancel` を追加。
 * `MouseTouchEventHandler` に `touchcancel` を追加。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.11.0-beta.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.11.0-beta.0",
+      "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.10.0",
+  "version": "2.11.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.10.0",
+      "version": "2.11.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.10.0",
+  "version": "2.11.0-beta.0",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.11.0-beta.0",
+  "version": "2.11.0",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/handler/MouseTouchEventHandler.ts
+++ b/src/handler/MouseTouchEventHandler.ts
@@ -21,6 +21,7 @@ export class MouseTouchEventHandler extends InputEventHandler {
 		this.inputView.addEventListener("touchstart", this.onTouchStart);
 		this.inputView.addEventListener("touchmove", this.onTouchMove);
 		this.inputView.addEventListener("touchend", this.onTouchEnd);
+		this.inputView.addEventListener("touchcancel", this.onTouchCancel);
 		this.inputView.addEventListener("contextmenu", preventEventDefault);
 	}
 
@@ -29,6 +30,7 @@ export class MouseTouchEventHandler extends InputEventHandler {
 		this.inputView.removeEventListener("touchstart", this.onTouchStart);
 		this.inputView.removeEventListener("touchmove", this.onTouchMove);
 		this.inputView.removeEventListener("touchend", this.onTouchEnd);
+		this.inputView.removeEventListener("touchcancel", this.onTouchCancel);
 		this.inputView.removeEventListener("contextmenu", preventEventDefault);
 	}
 
@@ -117,5 +119,10 @@ export class MouseTouchEventHandler extends InputEventHandler {
 		}
 		window.removeEventListener("touchmove", this.onTouchMove, false);
 		window.removeEventListener("touchend", this.onTouchEnd, false);
+		window.removeEventListener("touchcancel", this.onTouchCancel, false);
 	};
+
+	private onTouchCancel: (e: TouchEvent) => void =  e => {
+		this.onTouchEnd(e);
+	}
 }

--- a/src/handler/PointerEventHandler.ts
+++ b/src/handler/PointerEventHandler.ts
@@ -7,6 +7,7 @@ type EventHandlersMap = {
 	[pointerId: number]: {
 		onPointerMove: EventHandler;
 		onPointerUp: EventHandler;
+		onPointerCancel: EventHandler;
 	};
 };
 
@@ -81,15 +82,21 @@ export class PointerEventHandler extends InputEventHandler {
 			if (e.pointerId === event.pointerId) {
 				const handlers = this._eventHandlersMap[event.pointerId];
 				if (!handlers) return;
-				const { onPointerMove, onPointerUp } = handlers;
+				const { onPointerMove, onPointerUp, onPointerCancel } = handlers;
 				window.removeEventListener("pointermove", onPointerMove, false);
 				window.removeEventListener("pointerup", onPointerUp, false);
+				window.removeEventListener("pointercancel", onPointerCancel, false);
 				delete this._eventHandlersMap[event.pointerId];
 			}
 		};
 
+		const onPointerCancel = (event: PointerEvent): void => {
+			onPointerUp(event);
+		};
+
 		window.addEventListener("pointermove", onPointerMove, false);
 		window.addEventListener("pointerup", onPointerUp, false);
-		this._eventHandlersMap[e.pointerId] = { onPointerMove, onPointerUp };
+		window.addEventListener("pointercancel", onPointerCancel, false);
+		this._eventHandlersMap[e.pointerId] = { onPointerMove, onPointerUp, onPointerCancel };
 	};
 }


### PR DESCRIPTION
## 概要

`PointerEventHandler` に `pointercancel`, `MouseTouchEventHandler` に `touchcancel` を追加します。

完全な動作確認が取れていないため、動作確認が取れるまでマージしません。
