### PR TITLE
feat: support requests with withCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.10.5
+* `Platform#usingWithCredentials` を追加
+
 ## 2.10.4
 * ブラウザ上でタッチ操作がネイティブジェスチャー判定された時も `pointUp` イベントを発生させるように
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-browser",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-browser",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "An akashic-pdi implementation for Web browsers",
   "main": "index.js",
   "typings": "lib/full/index.d.ts",

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -57,6 +57,12 @@ export class Platform implements pdi.Platform {
 	 */
 	readonly usingPointerEvents: boolean = true;
 
+	/**
+	 * XHRLoader の利用時に withCredentials を有効にするかどうか。
+	 * 正規表現を指定した場合、対象の URL と一致した場合のみ有効にする。
+	 */
+	readonly usingWithCredentials: boolean | RegExp = false;
+
 	_platformEventHandler: pdi.PlatformEventHandler | null;
 	_resourceFactory: ResourceFactory;
 	_rendererReq: pdi.RendererRequirement | null;

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -61,7 +61,7 @@ export class Platform implements pdi.Platform {
 	 * XHRLoader の利用時に withCredentials を有効にするかどうか。
 	 * 正規表現を指定した場合、対象の URL と一致した場合のみ有効にする。
 	 */
-	readonly usingWithCredentials: boolean | RegExp = false;
+	usingWithCredentials: boolean | RegExp = false;
 
 	_platformEventHandler: pdi.PlatformEventHandler | null;
 	_resourceFactory: ResourceFactory;

--- a/src/ResourceFactory.ts
+++ b/src/ResourceFactory.ts
@@ -48,6 +48,7 @@ export class ResourceFactory implements pdi.ResourceFactory {
 			throw new Error("ResourceFactory#createAudioAsset(): could not initialize ActivePlugin");
 		}
 		const audioAsset = activePlugin.createAsset(id, assetPath, duration, system, loop, hint, offset);
+		audioAsset._withCredentials = this._platform.usingWithCredentials;
 		this._audioManager.registerAudioAsset(audioAsset);
 		audioAsset.onDestroyed.addOnce(this._onAudioAssetDestroyed, this);
 		return audioAsset;
@@ -78,11 +79,15 @@ export class ResourceFactory implements pdi.ResourceFactory {
 	}
 
 	createTextAsset(id: string, assetPath: string): pdi.TextAsset {
-		return new XHRTextAsset(id, assetPath);
+		const asset = new XHRTextAsset(id, assetPath);
+		asset._withCredentials = this._platform.usingWithCredentials;
+		return asset;
 	}
 
 	createScriptAsset(id: string, assetPath: string, exports?: string[]): pdi.ScriptAsset {
-		return new XHRScriptAsset(id, assetPath, exports);
+		const asset = new XHRScriptAsset(id, assetPath, exports);
+		asset._withCredentials = this._platform.usingWithCredentials;
+		return asset;
 	}
 
 	createPrimarySurface(width: number, height: number): CanvasSurface {
@@ -115,7 +120,9 @@ export class ResourceFactory implements pdi.ResourceFactory {
 	}
 
 	createBinaryAsset(id: string, assetPath: string): BinaryAsset {
-		return new BinaryAsset(id, assetPath);
+		const asset = new BinaryAsset(id, assetPath);
+		asset._withCredentials = this._platform.usingWithCredentials;
+		return asset;
 	}
 
 	_onAudioAssetDestroyed(asset: pdi.Asset): void {

--- a/src/asset/Asset.ts
+++ b/src/asset/Asset.ts
@@ -1,5 +1,6 @@
 import type * as pdi from "@akashic/pdi-types";
 import { Trigger } from "@akashic/trigger";
+import { XHRLoader } from "../utils/XHRLoader";
 
 export abstract class Asset implements pdi.Asset {
 	abstract type: string;
@@ -7,6 +8,8 @@ export abstract class Asset implements pdi.Asset {
 	path: string;
 	originalPath: string;
 	onDestroyed: Trigger<pdi.Asset> = new Trigger();
+
+	_withCredentials: boolean | RegExp = false;
 
 	constructor(id: string, path: string) {
 		this.id = id;
@@ -36,5 +39,12 @@ export abstract class Asset implements pdi.Asset {
 	_assetPathFilter(path: string): string {
 		// 拡張子の補完・読み替えが必要なassetはこれをオーバーライドすればよい。(対応形式が限定されるaudioなどの場合)
 		return path;
+	}
+
+	_createLoader(): XHRLoader {
+		const withCredentials = this._withCredentials instanceof RegExp
+			? this._withCredentials.test(this.path)
+			: this._withCredentials;
+		return new XHRLoader({ withCredentials });
 	}
 }

--- a/src/asset/BinaryAsset.ts
+++ b/src/asset/BinaryAsset.ts
@@ -1,5 +1,4 @@
 import type * as pdi from "@akashic/pdi-types";
-import { XHRLoader } from "../utils/XHRLoader";
 import { Asset } from "./Asset";
 
 export class BinaryAsset extends Asset implements pdi.BinaryAsset {
@@ -17,7 +16,7 @@ export class BinaryAsset extends Asset implements pdi.BinaryAsset {
 	}
 
 	_load(handler: pdi.AssetLoadHandler): void {
-		const loader = new XHRLoader();
+		const loader = this._createLoader();
 		loader.getArrayBuffer(this.path, (error, responseData) => {
 			if (error) {
 				handler._onAssetError(this, error);

--- a/src/asset/XHRScriptAsset.ts
+++ b/src/asset/XHRScriptAsset.ts
@@ -1,5 +1,4 @@
 import type * as pdi from "@akashic/pdi-types";
-import { XHRLoader } from "../utils/XHRLoader";
 import { Asset } from "./Asset";
 
 export class XHRScriptAsset extends Asset implements pdi.ScriptAsset {
@@ -13,7 +12,7 @@ export class XHRScriptAsset extends Asset implements pdi.ScriptAsset {
 	}
 
 	_load(handler: pdi.AssetLoadHandler): void {
-		const loader = new XHRLoader();
+		const loader = this._createLoader();
 		loader.get(this.path, (error, responseText) => {
 			if (error) {
 				handler._onAssetError(this, error);

--- a/src/asset/XHRTextAsset.ts
+++ b/src/asset/XHRTextAsset.ts
@@ -1,5 +1,4 @@
 import type * as pdi from "@akashic/pdi-types";
-import { XHRLoader } from "../utils/XHRLoader";
 import { Asset } from "./Asset";
 
 export class XHRTextAsset extends Asset implements pdi.TextAsset {
@@ -11,7 +10,7 @@ export class XHRTextAsset extends Asset implements pdi.TextAsset {
 	}
 
 	_load(handler: pdi.AssetLoadHandler): void {
-		const loader = new XHRLoader();
+		const loader = this._createLoader();
 		loader.get(this.path, (error, responseText) => {
 			if (error) {
 				handler._onAssetError(this, error);

--- a/src/plugin/WebAudioPlugin/WebAudioAsset.ts
+++ b/src/plugin/WebAudioPlugin/WebAudioAsset.ts
@@ -5,9 +5,11 @@ import { XHRLoader } from "../../utils/XHRLoader";
 import { addExtname, resolveExtname } from "../audioUtil";
 import * as helper from "./WebAudioHelper";
 
-export async function loadArrayBuffer(url: string): Promise<{ value: { audio: AudioBuffer; url: string }; size: number }> {
+export async function loadArrayBuffer(
+	url: string, withCredentials: boolean = false
+): Promise<{ value: { audio: AudioBuffer; url: string }; size: number }> {
 	function _loadArrayBuffer(url: string): Promise<{ value: { audio: AudioBuffer; url: string }; size: number }> {
-		const l = new XHRLoader();
+		const l = new XHRLoader({ withCredentials: withCredentials });
 		return new Promise((resolve, reject) => {
 			l.getArrayBuffer(url, (err, result) => {
 				if (err) {
@@ -57,7 +59,10 @@ export class WebAudioAsset extends AudioAsset {
 			return;
 		}
 
-		const load = this._loadFun ? this._loadFun : loadArrayBuffer;
+		const withCredentials = this._withCredentials instanceof RegExp
+			? this._withCredentials.test(this.path)
+			: this._withCredentials;
+		const load = this._loadFun ? this._loadFun : (url: string) => loadArrayBuffer(url, withCredentials);
 		load(this.path).then(data => {
 			// aac読み込み失敗時に代わりにmp4が読み込まれるなど、パスの拡張子が変わるケースがある
 			if (this.path !== data.value.url) {

--- a/src/utils/XHRLoader.ts
+++ b/src/utils/XHRLoader.ts
@@ -2,6 +2,7 @@
 import type * as pdi from "@akashic/pdi-types";
 import { ExceptionFactory } from "./ExceptionFactory";
 import type { XHRLoaderOption } from "./XHRLoaderOption";
+
 export interface XHRRequestObject {
 	url: string;
 	responseType: XMLHttpRequestResponseType;
@@ -9,11 +10,13 @@ export interface XHRRequestObject {
 
 export class XHRLoader {
 	timeout: number;
+	withCredentials: boolean;
 
 	constructor(options: XHRLoaderOption = {}) {
 		// デフォルトのタイムアウトは15秒
 		// TODO: タイムアウト値はこれが妥当であるか後日詳細を検討する
 		this.timeout = options.timeout || 15000;
+		this.withCredentials = options.withCredentials ?? false;
 	}
 
 	get(url: string, callback: (error: pdi.AssetLoadError | null, data?: string) => void): void {
@@ -35,6 +38,7 @@ export class XHRLoader {
 		request.open("GET", requestObject.url, true);
 		request.responseType = requestObject.responseType;
 		request.timeout = this.timeout;
+		request.withCredentials = this.withCredentials;
 		request.addEventListener("timeout", () => {
 			callback(ExceptionFactory.createAssetLoadError("loading timeout"));
 		}, false);

--- a/src/utils/XHRLoaderOption.ts
+++ b/src/utils/XHRLoaderOption.ts
@@ -1,3 +1,4 @@
 export interface XHRLoaderOption {
 	timeout?: number;
+	withCredentials?: boolean;
 }


### PR DESCRIPTION
# このPullRequestが解決する内容

`XHRLoader` の `withCredentials` を有効にするオプション `Platform#usingWithCredentials` を追加します。
正規表現を指定したらマッチする URL と、そうでなければ一律に有効にします。