### PR TITLE
chore: update package.json devEngines and .npmrc min-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -68,5 +68,12 @@
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/",
     "tag": "for_ae2x"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR updates both `package.json` (devEngines.packageManager) and `.npmrc` (min-release-age=7).